### PR TITLE
Pgbouncer panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.0.3 - 2019-02-11
+### Fixes
+- Doesn't panic on failed pgbouncer connection
+
 ## 1.0.2 - 2019-02-04
 ### Fixes
 - Added special case for parsing Debian versions

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -38,10 +38,10 @@ func PopulateMetrics(ci connection.Info, databaseList args.DatabaseList, instanc
 	PopulateIndexMetrics(databaseList, i, ci)
 	if collectPgBouncer {
 		con, err = ci.NewConnection("pgbouncer")
-		defer con.Close()
 		if err != nil {
 			log.Error("Error creating connection to pgbouncer database: %s", err)
 		} else {
+			defer con.Close()
 			PopulatePgBouncerMetrics(i, con, ci.Hostname())
 		}
 	}

--- a/src/postgresql.go
+++ b/src/postgresql.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	integrationName    = "com.newrelic.postgresql"
-	integrationVersion = "1.0.2"
+	integrationVersion = "1.0.3"
 )
 
 func main() {


### PR DESCRIPTION
#### Description of the changes

Previously, if attempting to open a connection to `pgbouncer` fails, it would defer a close on a nil connection. This waits to defer the close unless the connection is successfully created.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
