### PR TITLE
Database only collection list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.1.0 - 2019-05-23
+### Added
+- A collection list mode that allows collecting everything in a list of databases
+
 ## 2.0.0 - 2019-04-25
 ### Changes
 - Prefix entity namespaces with pg-

--- a/postgresql-config.yml.sample
+++ b/postgresql-config.yml.sample
@@ -17,10 +17,21 @@ instances:
       # The port of the postgres instance. If PgBouncer is being used,
       # use the port it is running on. Defaults to 5432
       port: 6432
-      # The JSON object which contains the entities to monitor. The nesting
-      # levels of JSON are database name -> schema name -> table name -> index name
-      # parameter is required for collection. If left as an empty JSON object nothing will be collected.
-      collection_list: '{"postgres":{"public":{"pg_table1":["pg_index1","pg_index2"],"pg_table2":[]}}}'
+      # Collection List can be either a JSON array or a JSON object. 
+      #
+      # If it is a JSON array, it will be interpreted as a list of database names to 
+      # collect all related metrics from. This will collect metrics for each database 
+      # specified, as well as all tables and indexes that belong to that database. 
+      # Example:
+      # collection_list: '["postgres"]'
+      #
+      # If it is a JSON object, you can more finely tune the entities that are collected. 
+      # Only the entities that are specified in the object will be collected. No automatic
+      # discovery will be performed.  
+      # The levels of JSON are database name -> schema name -> table name -> index name
+      # Example: 
+      # collection_list: '{"postgres":{"public":{"pg_table1":["pg_index1","pg_index2"],"pg_table2":[]}}}'
+      collection_list: '["postgres"]'
       # True if SSL is to be used. Defaults to false.
       enable_ssl: true
       # True if the SSL certificate should be trusted without validating.

--- a/src/args/argument_list.go
+++ b/src/args/argument_list.go
@@ -25,7 +25,6 @@ type ArgumentList struct {
 	Timeout                string `default:"10" help:"Maximum wait for connection, in seconds. Set 0 for no timeout"`
 }
 
-
 // Validate validates PostgreSQl arguments
 func (al ArgumentList) Validate() error {
 	if al.Username == "" || al.Password == "" {

--- a/src/args/argument_list.go
+++ b/src/args/argument_list.go
@@ -2,9 +2,7 @@
 package args
 
 import (
-	"encoding/json"
 	"errors"
-	"fmt"
 
 	sdkArgs "github.com/newrelic/infra-integrations-sdk/args"
 )
@@ -27,14 +25,6 @@ type ArgumentList struct {
 	Timeout                string `default:"10" help:"Maximum wait for connection, in seconds. Set 0 for no timeout"`
 }
 
-// DatabaseList is a map from database name to SchemaLists to collect
-type DatabaseList map[string]SchemaList
-
-// SchemaList is a map from schema name to TableList to collect
-type SchemaList map[string]TableList
-
-// TableList is a map from table name to an array of indexes to collect
-type TableList map[string][]string
 
 // Validate validates PostgreSQl arguments
 func (al ArgumentList) Validate() error {
@@ -44,12 +34,6 @@ func (al ArgumentList) Validate() error {
 
 	if err := al.validateSSL(); err != nil {
 		return err
-	}
-
-	var dl DatabaseList
-	err := json.Unmarshal([]byte(al.CollectionList), &dl)
-	if err != nil {
-		return fmt.Errorf("invalid configuration: failed to unmarshal CollectionList JSON: %s", err.Error())
 	}
 
 	return nil
@@ -67,12 +51,4 @@ func (al ArgumentList) validateSSL() error {
 	}
 
 	return nil
-}
-
-// GetCollectionList unmarshals the argument collection list into a DatabaseList
-func (al ArgumentList) GetCollectionList() DatabaseList {
-	var dl DatabaseList
-	_ = json.Unmarshal([]byte(al.CollectionList), &dl) // already checked in Validate()
-
-	return dl
 }

--- a/src/collection/collection.go
+++ b/src/collection/collection.go
@@ -1,0 +1,88 @@
+package collection
+
+import (
+  "encoding/json"
+  "errors"
+
+  "github.com/newrelic/infra-integrations-sdk/log"
+  "github.com/newrelic/nri-postgresql/src/args"
+  "github.com/newrelic/nri-postgresql/src/connection"
+) 
+
+// DatabaseList is a map from database name to SchemaLists to collect
+type DatabaseList map[string]SchemaList
+
+// SchemaList is a map from schema name to TableList to collect
+type SchemaList map[string]TableList
+
+// TableList is a map from table name to an array of indexes to collect
+type TableList map[string][]string
+
+// BuildCollectionList unmarshals the collection_list from the args and builds the list of 
+// objects to be collected. If collection_list is a JSON array, it collects every object in
+// each of the databases listed in the array. If it is a hash, it collects only the objects
+// listed
+func BuildCollectionList(al args.ArgumentList, ci connection.Info) (DatabaseList, error) {
+  var dl DatabaseList
+  if err := json.Unmarshal([]byte(al.CollectionList), &dl); err == nil {
+    return dl, nil
+  }
+
+  var dbnames []string
+  if err := json.Unmarshal([]byte(al.CollectionList), &dbnames); err == nil {
+    return buildCollectionListFromDatabaseNames(dbnames, ci)
+  }
+
+  return nil, errors.New("failed to parse collection list")
+}
+
+func buildCollectionListFromDatabaseNames(dbnames []string, ci connection.Info) (DatabaseList, error){
+  databaseList := make(DatabaseList)
+  for _, db := range dbnames {
+    schemaList := make(SchemaList)
+    con, err := ci.NewConnection(ci.DatabaseName())
+    if err != nil {
+      log.Error("connection to database %s failed: %s", db, err.Error())
+      continue
+    }
+
+    query := `select 
+        table_schema as schema_name,
+        t1.table_name as table_name,
+        t2.indexname as index_name
+      from information_schema.tables as t1
+      full outer join pg_indexes t2 
+        on t2.tablename = t1.table_name
+        and t2.schemaname = t1.table_schema;`
+
+
+    var dataModel []struct {
+      SchemaName *string `db:"schema_name"`
+      TableName  *string `db:"table_name"`
+      IndexName *string `db:"index_name"`
+    }
+    err = con.Query(&dataModel, query)
+    if err != nil {
+      return nil, err
+    }
+
+    for _, row := range dataModel {
+      if _, ok := schemaList[*row.SchemaName]; !ok {
+        schemaList[*row.SchemaName] = make(TableList)
+      }
+
+      if _, ok := schemaList[*row.TableName]; !ok {
+        schemaList[*row.SchemaName][*row.TableName] = make([]string,0)
+      }
+
+      if row.IndexName != nil {
+        schemaList[*row.SchemaName][*row.TableName] = append(schemaList[*row.SchemaName][*row.TableName], *row.IndexName)
+      }
+    }
+
+    databaseList[db] = schemaList
+  }
+
+  return databaseList, nil
+}
+

--- a/src/collection/collection.go
+++ b/src/collection/collection.go
@@ -1,12 +1,12 @@
 package collection
 
 import (
-  "encoding/json"
-  "errors"
+	"encoding/json"
+	"errors"
 
-  "github.com/newrelic/nri-postgresql/src/args"
-  "github.com/newrelic/nri-postgresql/src/connection"
-) 
+	"github.com/newrelic/nri-postgresql/src/args"
+	"github.com/newrelic/nri-postgresql/src/connection"
+)
 
 // DatabaseList is a map from database name to SchemaLists to collect
 type DatabaseList map[string]SchemaList
@@ -17,47 +17,47 @@ type SchemaList map[string]TableList
 // TableList is a map from table name to an array of indexes to collect
 type TableList map[string][]string
 
-// BuildCollectionList unmarshals the collection_list from the args and builds the list of 
+// BuildCollectionList unmarshals the collection_list from the args and builds the list of
 // objects to be collected. If collection_list is a JSON array, it collects every object in
 // each of the databases listed in the array. If it is a hash, it collects only the objects
 // listed
 func BuildCollectionList(al args.ArgumentList, ci connection.Info) (DatabaseList, error) {
-  var dl DatabaseList
-  if err := json.Unmarshal([]byte(al.CollectionList), &dl); err == nil {
-    return dl, nil
-  }
+	var dl DatabaseList
+	if err := json.Unmarshal([]byte(al.CollectionList), &dl); err == nil {
+		return dl, nil
+	}
 
-  var dbnames []string
-  if err := json.Unmarshal([]byte(al.CollectionList), &dbnames); err == nil {
-    return buildCollectionListFromDatabaseNames(dbnames, ci)
-  }
+	var dbnames []string
+	if err := json.Unmarshal([]byte(al.CollectionList), &dbnames); err == nil {
+		return buildCollectionListFromDatabaseNames(dbnames, ci)
+	}
 
-  return nil, errors.New("failed to parse collection list")
+	return nil, errors.New("failed to parse collection list")
 }
 
-func buildCollectionListFromDatabaseNames(dbnames []string, ci connection.Info) (DatabaseList, error){
-  databaseList := make(DatabaseList)
-  for _, db := range dbnames {
-    con, err := ci.NewConnection(db)
-    if err != nil {
-      return nil, err
-    }
+func buildCollectionListFromDatabaseNames(dbnames []string, ci connection.Info) (DatabaseList, error) {
+	databaseList := make(DatabaseList)
+	for _, db := range dbnames {
+		con, err := ci.NewConnection(db)
+		if err != nil {
+			return nil, err
+		}
 
-    schemaList, err := buildSchemaListForDatabase(db, con)
-    if err != nil {
-      return nil, err
-    }
+		schemaList, err := buildSchemaListForDatabase(db, con)
+		if err != nil {
+			return nil, err
+		}
 
-    databaseList[db] = schemaList
-  }
+		databaseList[db] = schemaList
+	}
 
-  return databaseList, nil
+	return databaseList, nil
 }
 
 func buildSchemaListForDatabase(dbname string, con *connection.PGSQLConnection) (SchemaList, error) {
-  schemaList := make(SchemaList)
+	schemaList := make(SchemaList)
 
-  query := `select 
+	query := `select 
       table_schema as schema_name,
       t1.table_name as table_name,
       t2.indexname as index_name
@@ -66,30 +66,29 @@ func buildSchemaListForDatabase(dbname string, con *connection.PGSQLConnection) 
       on t2.tablename = t1.table_name
       and t2.schemaname = t1.table_schema;`
 
+	var dataModel []struct {
+		SchemaName *string `db:"schema_name"`
+		TableName  *string `db:"table_name"`
+		IndexName  *string `db:"index_name"`
+	}
+	err := con.Query(&dataModel, query)
+	if err != nil {
+		return nil, err
+	}
 
-  var dataModel []struct {
-    SchemaName *string `db:"schema_name"`
-    TableName  *string `db:"table_name"`
-    IndexName *string `db:"index_name"`
-  }
-  err := con.Query(&dataModel, query)
-  if err != nil {
-    return nil, err
-  }
+	for _, row := range dataModel {
+		if _, ok := schemaList[*row.SchemaName]; !ok {
+			schemaList[*row.SchemaName] = make(TableList)
+		}
 
-  for _, row := range dataModel {
-    if _, ok := schemaList[*row.SchemaName]; !ok {
-      schemaList[*row.SchemaName] = make(TableList)
-    }
+		if _, ok := schemaList[*row.TableName]; !ok {
+			schemaList[*row.SchemaName][*row.TableName] = make([]string, 0)
+		}
 
-    if _, ok := schemaList[*row.TableName]; !ok {
-      schemaList[*row.SchemaName][*row.TableName] = make([]string,0)
-    }
+		if row.IndexName != nil {
+			schemaList[*row.SchemaName][*row.TableName] = append(schemaList[*row.SchemaName][*row.TableName], *row.IndexName)
+		}
+	}
 
-    if row.IndexName != nil {
-      schemaList[*row.SchemaName][*row.TableName] = append(schemaList[*row.SchemaName][*row.TableName], *row.IndexName)
-    }
-  }
-
-  return schemaList, nil
+	return schemaList, nil
 }

--- a/src/collection/collection_test.go
+++ b/src/collection/collection_test.go
@@ -1,0 +1,103 @@
+package collection
+
+import (
+  "testing"
+
+  "github.com/newrelic/nri-postgresql/src/connection"
+  "github.com/newrelic/nri-postgresql/src/args"
+  "github.com/stretchr/testify/assert"
+  "gopkg.in/DATA-DOG/go-sqlmock.v1"
+
+)
+
+func Test_buildSchemaListForDatabase(t *testing.T) {
+  testConnection, mock := connection.CreateMockSQL(t)
+  instanceRows := sqlmock.NewRows([]string{
+    "schema_name",
+    "table_name",
+    "index_name",
+  }).AddRow("schema1","table1","index1")
+
+  mock.ExpectQuery(".*").WillReturnRows(instanceRows)
+
+  schemaList, err := buildSchemaListForDatabase("database1", testConnection)
+  assert.Nil(t, err)
+
+  expected := SchemaList{
+    "schema1": TableList{
+      "table1": []string{ "index1" },
+    },
+  }
+
+  assert.Equal(t, expected, schemaList)
+}
+
+func Test_buildSchemaListForDatabase_TableOnly(t *testing.T) {
+  testConnection, mock := connection.CreateMockSQL(t)
+  instanceRows := sqlmock.NewRows([]string{
+    "schema_name",
+    "table_name",
+    "index_name",
+  }).AddRow("schema1","table1","index1").AddRow("schema2","table2", nil)
+
+  mock.ExpectQuery(".*").WillReturnRows(instanceRows)
+
+  schemaList, err := buildSchemaListForDatabase("database1", testConnection)
+  assert.Nil(t, err)
+
+  expected := SchemaList{
+    "schema1": TableList{
+      "table1": []string{ "index1" },
+    },
+    "schema2": TableList{
+      "table2": []string{},
+    },
+  }
+
+  assert.Equal(t, expected, schemaList)
+}
+
+func TestBuildCollectionList_DatabaseList(t *testing.T) {
+
+  al := args.ArgumentList{
+    CollectionList: `["database1", "database2"]`,
+  }
+
+  ci := connection.MockInfo{}
+  testConnection1, mock1 := connection.CreateMockSQL(t)
+  testConnection2, mock2 := connection.CreateMockSQL(t)
+
+  ci.On("NewConnection", "database1").Return(testConnection1, nil)
+  ci.On("NewConnection", "database2").Return(testConnection2, nil)
+
+  instanceRows1 := sqlmock.NewRows([]string{
+    "schema_name",
+    "table_name",
+    "index_name",
+  }).AddRow("schema1","table1","index1")
+  instanceRows2 := sqlmock.NewRows([]string{
+    "schema_name",
+    "table_name",
+    "index_name",
+  }).AddRow("schema2","table2", nil)
+
+  mock1.ExpectQuery(".*").WillReturnRows(instanceRows1)
+  mock2.ExpectQuery(".*").WillReturnRows(instanceRows2)
+
+  expected := DatabaseList{
+    "database1": SchemaList{
+      "schema1": TableList{
+        "table1": []string{ "index1" },
+      },
+    },
+    "database2": SchemaList{
+      "schema2": TableList{
+        "table2": []string{},
+      },
+    },
+  }
+
+  dl, err := BuildCollectionList(al, &ci)
+  assert.Nil(t, err)
+  assert.Equal(t, expected, dl)
+}

--- a/src/collection/collection_test.go
+++ b/src/collection/collection_test.go
@@ -100,3 +100,35 @@ func TestBuildCollectionList_DatabaseList(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, expected, dl)
 }
+
+func TestBuildCollectionList_DetailedList(t *testing.T) {
+
+	al := args.ArgumentList{
+    CollectionList: `{"database1": {"schema1": { "table1": ["index1"] }}}`,
+	}
+
+	ci := connection.MockInfo{}
+	testConnection, mock := connection.CreateMockSQL(t)
+
+	ci.On("NewConnection", "database1").Return(testConnection, nil)
+
+	instanceRows := sqlmock.NewRows([]string{
+		"schema_name",
+		"table_name",
+		"index_name",
+	}).AddRow("schema1", "table1", "index1")
+
+	mock.ExpectQuery(".*").WillReturnRows(instanceRows)
+
+	expected := DatabaseList{
+		"database1": SchemaList{
+			"schema1": TableList{
+				"table1": []string{"index1"},
+			},
+		},
+	}
+
+	dl, err := BuildCollectionList(al, &ci)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, dl)
+}

--- a/src/collection/collection_test.go
+++ b/src/collection/collection_test.go
@@ -1,103 +1,102 @@
 package collection
 
 import (
-  "testing"
+	"testing"
 
-  "github.com/newrelic/nri-postgresql/src/connection"
-  "github.com/newrelic/nri-postgresql/src/args"
-  "github.com/stretchr/testify/assert"
-  "gopkg.in/DATA-DOG/go-sqlmock.v1"
-
+	"github.com/newrelic/nri-postgresql/src/args"
+	"github.com/newrelic/nri-postgresql/src/connection"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 func Test_buildSchemaListForDatabase(t *testing.T) {
-  testConnection, mock := connection.CreateMockSQL(t)
-  instanceRows := sqlmock.NewRows([]string{
-    "schema_name",
-    "table_name",
-    "index_name",
-  }).AddRow("schema1","table1","index1")
+	testConnection, mock := connection.CreateMockSQL(t)
+	instanceRows := sqlmock.NewRows([]string{
+		"schema_name",
+		"table_name",
+		"index_name",
+	}).AddRow("schema1", "table1", "index1")
 
-  mock.ExpectQuery(".*").WillReturnRows(instanceRows)
+	mock.ExpectQuery(".*").WillReturnRows(instanceRows)
 
-  schemaList, err := buildSchemaListForDatabase("database1", testConnection)
-  assert.Nil(t, err)
+	schemaList, err := buildSchemaListForDatabase("database1", testConnection)
+	assert.Nil(t, err)
 
-  expected := SchemaList{
-    "schema1": TableList{
-      "table1": []string{ "index1" },
-    },
-  }
+	expected := SchemaList{
+		"schema1": TableList{
+			"table1": []string{"index1"},
+		},
+	}
 
-  assert.Equal(t, expected, schemaList)
+	assert.Equal(t, expected, schemaList)
 }
 
 func Test_buildSchemaListForDatabase_TableOnly(t *testing.T) {
-  testConnection, mock := connection.CreateMockSQL(t)
-  instanceRows := sqlmock.NewRows([]string{
-    "schema_name",
-    "table_name",
-    "index_name",
-  }).AddRow("schema1","table1","index1").AddRow("schema2","table2", nil)
+	testConnection, mock := connection.CreateMockSQL(t)
+	instanceRows := sqlmock.NewRows([]string{
+		"schema_name",
+		"table_name",
+		"index_name",
+	}).AddRow("schema1", "table1", "index1").AddRow("schema2", "table2", nil)
 
-  mock.ExpectQuery(".*").WillReturnRows(instanceRows)
+	mock.ExpectQuery(".*").WillReturnRows(instanceRows)
 
-  schemaList, err := buildSchemaListForDatabase("database1", testConnection)
-  assert.Nil(t, err)
+	schemaList, err := buildSchemaListForDatabase("database1", testConnection)
+	assert.Nil(t, err)
 
-  expected := SchemaList{
-    "schema1": TableList{
-      "table1": []string{ "index1" },
-    },
-    "schema2": TableList{
-      "table2": []string{},
-    },
-  }
+	expected := SchemaList{
+		"schema1": TableList{
+			"table1": []string{"index1"},
+		},
+		"schema2": TableList{
+			"table2": []string{},
+		},
+	}
 
-  assert.Equal(t, expected, schemaList)
+	assert.Equal(t, expected, schemaList)
 }
 
 func TestBuildCollectionList_DatabaseList(t *testing.T) {
 
-  al := args.ArgumentList{
-    CollectionList: `["database1", "database2"]`,
-  }
+	al := args.ArgumentList{
+		CollectionList: `["database1", "database2"]`,
+	}
 
-  ci := connection.MockInfo{}
-  testConnection1, mock1 := connection.CreateMockSQL(t)
-  testConnection2, mock2 := connection.CreateMockSQL(t)
+	ci := connection.MockInfo{}
+	testConnection1, mock1 := connection.CreateMockSQL(t)
+	testConnection2, mock2 := connection.CreateMockSQL(t)
 
-  ci.On("NewConnection", "database1").Return(testConnection1, nil)
-  ci.On("NewConnection", "database2").Return(testConnection2, nil)
+	ci.On("NewConnection", "database1").Return(testConnection1, nil)
+	ci.On("NewConnection", "database2").Return(testConnection2, nil)
 
-  instanceRows1 := sqlmock.NewRows([]string{
-    "schema_name",
-    "table_name",
-    "index_name",
-  }).AddRow("schema1","table1","index1")
-  instanceRows2 := sqlmock.NewRows([]string{
-    "schema_name",
-    "table_name",
-    "index_name",
-  }).AddRow("schema2","table2", nil)
+	instanceRows1 := sqlmock.NewRows([]string{
+		"schema_name",
+		"table_name",
+		"index_name",
+	}).AddRow("schema1", "table1", "index1")
+	instanceRows2 := sqlmock.NewRows([]string{
+		"schema_name",
+		"table_name",
+		"index_name",
+	}).AddRow("schema2", "table2", nil)
 
-  mock1.ExpectQuery(".*").WillReturnRows(instanceRows1)
-  mock2.ExpectQuery(".*").WillReturnRows(instanceRows2)
+	mock1.ExpectQuery(".*").WillReturnRows(instanceRows1)
+	mock2.ExpectQuery(".*").WillReturnRows(instanceRows2)
 
-  expected := DatabaseList{
-    "database1": SchemaList{
-      "schema1": TableList{
-        "table1": []string{ "index1" },
-      },
-    },
-    "database2": SchemaList{
-      "schema2": TableList{
-        "table2": []string{},
-      },
-    },
-  }
+	expected := DatabaseList{
+		"database1": SchemaList{
+			"schema1": TableList{
+				"table1": []string{"index1"},
+			},
+		},
+		"database2": SchemaList{
+			"schema2": TableList{
+				"table2": []string{},
+			},
+		},
+	}
 
-  dl, err := BuildCollectionList(al, &ci)
-  assert.Nil(t, err)
-  assert.Equal(t, expected, dl)
+	dl, err := BuildCollectionList(al, &ci)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, dl)
 }

--- a/src/metrics/database_definitions.go
+++ b/src/metrics/database_definitions.go
@@ -4,10 +4,10 @@ import (
 	"strings"
 
 	"github.com/blang/semver"
-	"github.com/newrelic/nri-postgresql/src/args"
+	"github.com/newrelic/nri-postgresql/src/collection"
 )
 
-func generateDatabaseDefinitions(databases args.DatabaseList, version *semver.Version) []*QueryDefinition {
+func generateDatabaseDefinitions(databases collection.DatabaseList, version *semver.Version) []*QueryDefinition {
 	queryDefinitions := make([]*QueryDefinition, 0, 2)
 	if len(databases) == 0 {
 		return queryDefinitions
@@ -29,7 +29,7 @@ func generateDatabaseDefinitions(databases args.DatabaseList, version *semver.Ve
 	return queryDefinitions
 }
 
-func (q *QueryDefinition) insertDatabaseNames(databases args.DatabaseList) *QueryDefinition {
+func (q *QueryDefinition) insertDatabaseNames(databases collection.DatabaseList) *QueryDefinition {
 	// TODO ensure len(databases) != 0
 	databaseList := ""
 	for database := range databases {

--- a/src/metrics/database_definitions_test.go
+++ b/src/metrics/database_definitions_test.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
-	"github.com/newrelic/nri-postgresql/src/args"
+	"github.com/newrelic/nri-postgresql/src/collection"
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_generateDatabaseDefinitions_LengthV8(t *testing.T) {
 	v8 := semver.MustParse("8.0.0")
 
-	databaseList := args.DatabaseList{"test1": {}}
+	databaseList := collection.DatabaseList{"test1": {}}
 
 	queryDefinitions := generateDatabaseDefinitions(databaseList, &v8)
 
@@ -21,7 +21,7 @@ func Test_generateDatabaseDefinitions_LengthV8(t *testing.T) {
 
 func Test_generateDatabaseDefinitions_LengthV912(t *testing.T) {
 	v912 := semver.MustParse("9.1.2")
-	databaseList := args.DatabaseList{"test1": {}}
+	databaseList := collection.DatabaseList{"test1": {}}
 
 	queryDefinitions := generateDatabaseDefinitions(databaseList, &v912)
 
@@ -30,7 +30,7 @@ func Test_generateDatabaseDefinitions_LengthV912(t *testing.T) {
 
 func Test_generateDatabaseDefinitions_LengthV925(t *testing.T) {
 	v925 := semver.MustParse("9.2.5")
-	databaseList := args.DatabaseList{"test1": {}}
+	databaseList := collection.DatabaseList{"test1": {}}
 
 	queryDefinitions := generateDatabaseDefinitions(databaseList, &v925)
 
@@ -43,7 +43,7 @@ func Test_insertDatabaseNames(t *testing.T) {
 		dataModels: &[]struct{}{},
 	}
 
-	databaseList := args.DatabaseList{"test1": {}, "test2": {}}
+	databaseList := collection.DatabaseList{"test1": {}, "test2": {}}
 	testDefinition.insertDatabaseNames(databaseList)
 
 	expectedRegexp := `SELECT \* FROM test WHERE database IN \('test[12]','test[12]'\);`

--- a/src/metrics/index_definitions.go
+++ b/src/metrics/index_definitions.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/newrelic/nri-postgresql/src/args"
+	"github.com/newrelic/nri-postgresql/src/collection"
 )
 
-func generateIndexDefinitions(schemaList args.SchemaList) []*QueryDefinition {
+func generateIndexDefinitions(schemaList collection.SchemaList) []*QueryDefinition {
 	queryDefinitions := make([]*QueryDefinition, 0)
 	if def := indexDefinition.insertSchemaTableIndexes(schemaList); def != nil {
 		queryDefinitions = append(queryDefinitions, def)
@@ -16,7 +16,7 @@ func generateIndexDefinitions(schemaList args.SchemaList) []*QueryDefinition {
 	return queryDefinitions
 }
 
-func (qd *QueryDefinition) insertSchemaTableIndexes(schemaList args.SchemaList) *QueryDefinition {
+func (qd *QueryDefinition) insertSchemaTableIndexes(schemaList collection.SchemaList) *QueryDefinition {
 	schemaTableIndexes := make([]string, 0)
 	for schema, tableList := range schemaList {
 		for table, indexList := range tableList {

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -8,7 +8,7 @@ import (
 	"github.com/newrelic/infra-integrations-sdk/data/metric"
 	"github.com/newrelic/infra-integrations-sdk/integration"
 	"github.com/newrelic/infra-integrations-sdk/log"
-	"github.com/newrelic/nri-postgresql/src/args"
+	"github.com/newrelic/nri-postgresql/src/collection"
 	"github.com/newrelic/nri-postgresql/src/connection"
 )
 
@@ -17,7 +17,7 @@ const (
 )
 
 // PopulateMetrics collects metrics for each type
-func PopulateMetrics(ci connection.Info, databaseList args.DatabaseList, instance *integration.Entity, i *integration.Integration, collectPgBouncer bool) {
+func PopulateMetrics(ci connection.Info, databaseList collection.DatabaseList, instance *integration.Entity, i *integration.Integration, collectPgBouncer bool) {
 
 	con, err := ci.NewConnection(ci.DatabaseName())
 	if err != nil {
@@ -115,7 +115,7 @@ func PopulateInstanceMetrics(instanceEntity *integration.Entity, version *semver
 }
 
 // PopulateDatabaseMetrics populates the metrics for a database
-func PopulateDatabaseMetrics(databases args.DatabaseList, version *semver.Version, pgIntegration *integration.Integration, connection *connection.PGSQLConnection, ci connection.Info) {
+func PopulateDatabaseMetrics(databases collection.DatabaseList, version *semver.Version, pgIntegration *integration.Integration, connection *connection.PGSQLConnection, ci connection.Info) {
 	databaseDefinitions := generateDatabaseDefinitions(databases, version)
 
 	for _, queryDef := range databaseDefinitions {
@@ -156,7 +156,7 @@ func PopulateDatabaseMetrics(databases args.DatabaseList, version *semver.Versio
 }
 
 // PopulateTableMetrics populates the metrics for a table
-func PopulateTableMetrics(databases args.DatabaseList, pgIntegration *integration.Integration, ci connection.Info) {
+func PopulateTableMetrics(databases collection.DatabaseList, pgIntegration *integration.Integration, ci connection.Info) {
 	for database, schemaList := range databases {
 		if len(schemaList) == 0 {
 			return
@@ -174,7 +174,7 @@ func PopulateTableMetrics(databases args.DatabaseList, pgIntegration *integratio
 	}
 }
 
-func populateTableMetricsForDatabase(schemaList args.SchemaList, con *connection.PGSQLConnection, pgIntegration *integration.Integration, ci connection.Info) {
+func populateTableMetricsForDatabase(schemaList collection.SchemaList, con *connection.PGSQLConnection, pgIntegration *integration.Integration, ci connection.Info) {
 
 	tableDefinitions := generateTableDefinitions(schemaList)
 
@@ -229,7 +229,7 @@ func populateTableMetricsForDatabase(schemaList args.SchemaList, con *connection
 }
 
 // PopulateIndexMetrics populates the metrics for an index
-func PopulateIndexMetrics(databases args.DatabaseList, pgIntegration *integration.Integration, ci connection.Info) {
+func PopulateIndexMetrics(databases collection.DatabaseList, pgIntegration *integration.Integration, ci connection.Info) {
 	for database, schemaList := range databases {
 		con, err := ci.NewConnection(database)
 		defer con.Close()
@@ -241,7 +241,7 @@ func PopulateIndexMetrics(databases args.DatabaseList, pgIntegration *integratio
 	}
 }
 
-func populateIndexMetricsForDatabase(schemaList args.SchemaList, con *connection.PGSQLConnection, pgIntegration *integration.Integration, ci connection.Info) {
+func populateIndexMetricsForDatabase(schemaList collection.SchemaList, con *connection.PGSQLConnection, pgIntegration *integration.Integration, ci connection.Info) {
 	indexDefinitions := generateIndexDefinitions(schemaList)
 
 	for _, definition := range indexDefinitions {

--- a/src/metrics/metrics_test.go
+++ b/src/metrics/metrics_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/newrelic/infra-integrations-sdk/integration"
-	"github.com/newrelic/nri-postgresql/src/args"
+	"github.com/newrelic/nri-postgresql/src/collection"
 	"github.com/newrelic/nri-postgresql/src/connection"
 	"github.com/stretchr/testify/assert"
 	tmock "github.com/stretchr/testify/mock"
@@ -85,7 +85,7 @@ func TestPopulateDatabaseMetrics(t *testing.T) {
 	testIntegration, _ := integration.New("test", "test")
 
 	version := semver.MustParse("9.0.0")
-	dbList := args.DatabaseList{"test1": {}}
+	dbList := collection.DatabaseList{"test1": {}}
 
 	testConnection, mock := connection.CreateMockSQL(t)
 	databaseRows := sqlmock.NewRows([]string{
@@ -133,9 +133,9 @@ func TestPopulateDatabaseMetrics(t *testing.T) {
 func Test_populateTableMetricsForDatabase(t *testing.T) {
 	testIntegration, _ := integration.New("test", "test")
 
-	dbList := args.DatabaseList{
-		"db1": args.SchemaList{
-			"schema1": args.TableList{
+	dbList := collection.DatabaseList{
+		"db1": collection.SchemaList{
+			"schema1": collection.TableList{
 				"table1": []string{},
 			},
 		},
@@ -235,9 +235,9 @@ func Test_populateTableMetricsForDatabase(t *testing.T) {
 func Test_populateTableMetricsForDatabase_noTables(t *testing.T) {
 	testIntegration, _ := integration.New("test", "test")
 
-	dbList := args.DatabaseList{
-		"db1": args.SchemaList{
-			"schema1": args.TableList{},
+	dbList := collection.DatabaseList{
+		"db1": collection.SchemaList{
+			"schema1": collection.TableList{},
 		},
 	}
 
@@ -255,9 +255,9 @@ func Test_populateTableMetricsForDatabase_noTables(t *testing.T) {
 func Test_populateIndexMetricsForDatabase(t *testing.T) {
 	testIntegration, _ := integration.New("test", "test")
 
-	dbList := args.DatabaseList{
-		"db1": args.SchemaList{
-			"schema1": args.TableList{
+	dbList := collection.DatabaseList{
+		"db1": collection.SchemaList{
+			"schema1": collection.TableList{
 				"table1": []string{
 					"index1",
 				},
@@ -307,9 +307,9 @@ func Test_populateIndexMetricsForDatabase(t *testing.T) {
 func Test_populateIndexMetricsForDatabase_noIndexes(t *testing.T) {
 	testIntegration, _ := integration.New("test", "test")
 
-	dbList := args.DatabaseList{
-		"db1": args.SchemaList{
-			"schema1": args.TableList{
+	dbList := collection.DatabaseList{
+		"db1": collection.SchemaList{
+			"schema1": collection.TableList{
 				"table1": []string{},
 			},
 		},
@@ -415,9 +415,9 @@ func TestPopulatePgBouncerMetrics(t *testing.T) {
 func TestPopulateMetrics(t *testing.T) {
 	testIntegration, _ := integration.New("test", "test")
 
-	dbList := args.DatabaseList{
-		"db1": args.SchemaList{
-			"schema1": args.TableList{
+	dbList := collection.DatabaseList{
+		"db1": collection.SchemaList{
+			"schema1": collection.TableList{
 				"table1": []string{
 					"index1",
 				},

--- a/src/metrics/table_definitions.go
+++ b/src/metrics/table_definitions.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/newrelic/nri-postgresql/src/args"
+	"github.com/newrelic/nri-postgresql/src/collection"
 )
 
-func generateTableDefinitions(schemaList args.SchemaList) []*QueryDefinition {
+func generateTableDefinitions(schemaList collection.SchemaList) []*QueryDefinition {
 	queryDefinitions := make([]*QueryDefinition, 0)
 	if def := tableBloatDefinition.insertSchemaTables(schemaList); def != nil {
 		queryDefinitions = append(queryDefinitions, def)
@@ -19,7 +19,7 @@ func generateTableDefinitions(schemaList args.SchemaList) []*QueryDefinition {
 	return queryDefinitions
 }
 
-func (qd *QueryDefinition) insertSchemaTables(schemaList args.SchemaList) *QueryDefinition {
+func (qd *QueryDefinition) insertSchemaTables(schemaList collection.SchemaList) *QueryDefinition {
 	schemaTables := make([]string, 0)
 	for schema, tableList := range schemaList {
 		for table := range tableList {

--- a/src/postgresql.go
+++ b/src/postgresql.go
@@ -7,8 +7,8 @@ import (
 	"github.com/newrelic/infra-integrations-sdk/integration"
 	"github.com/newrelic/infra-integrations-sdk/log"
 	"github.com/newrelic/nri-postgresql/src/args"
-	"github.com/newrelic/nri-postgresql/src/connection"
 	"github.com/newrelic/nri-postgresql/src/collection"
+	"github.com/newrelic/nri-postgresql/src/connection"
 	"github.com/newrelic/nri-postgresql/src/inventory"
 	"github.com/newrelic/nri-postgresql/src/metrics"
 )
@@ -37,11 +37,11 @@ func main() {
 	}
 
 	connectionInfo := connection.DefaultConnectionInfo(&args)
-  collectionList, err := collection.BuildCollectionList(args, connectionInfo)
-  if err != nil {
-    log.Error("Error creating list of entities to collect: %s", err)
-    os.Exit(1)
-  }
+	collectionList, err := collection.BuildCollectionList(args, connectionInfo)
+	if err != nil {
+		log.Error("Error creating list of entities to collect: %s", err)
+		os.Exit(1)
+	}
 
 	instance, err := postgresIntegration.Entity(fmt.Sprintf("%s:%s", args.Hostname, args.Port), "pg-instance")
 	if err != nil {
@@ -67,4 +67,3 @@ func main() {
 		log.Error(err.Error())
 	}
 }
-

--- a/src/postgresql.go
+++ b/src/postgresql.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	integrationName    = "com.newrelic.postgresql"
-	integrationVersion = "2.0.0"
+	integrationVersion = "2.1.0"
 )
 
 func main() {

--- a/src/postgresql.go
+++ b/src/postgresql.go
@@ -8,6 +8,7 @@ import (
 	"github.com/newrelic/infra-integrations-sdk/log"
 	"github.com/newrelic/nri-postgresql/src/args"
 	"github.com/newrelic/nri-postgresql/src/connection"
+	"github.com/newrelic/nri-postgresql/src/collection"
 	"github.com/newrelic/nri-postgresql/src/inventory"
 	"github.com/newrelic/nri-postgresql/src/metrics"
 )
@@ -35,8 +36,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	databaseList := args.GetCollectionList()
 	connectionInfo := connection.DefaultConnectionInfo(&args)
+  collectionList, err := collection.BuildCollectionList(args, connectionInfo)
+  if err != nil {
+    log.Error("Error creating list of entities to collect: %s", err)
+    os.Exit(1)
+  }
 
 	instance, err := postgresIntegration.Entity(fmt.Sprintf("%s:%s", args.Hostname, args.Port), "pg-instance")
 	if err != nil {
@@ -45,7 +50,7 @@ func main() {
 	}
 
 	if args.HasMetrics() {
-		metrics.PopulateMetrics(connectionInfo, databaseList, instance, postgresIntegration, args.Pgbouncer)
+		metrics.PopulateMetrics(connectionInfo, collectionList, instance, postgresIntegration, args.Pgbouncer)
 	}
 
 	if args.HasInventory() {
@@ -62,3 +67,4 @@ func main() {
 		log.Error(err.Error())
 	}
 }
+


### PR DESCRIPTION
#### Description of the changes

A highly requested feature is for users to be able to collect everything in a database without the strange nested syntax required before. This allows `collection_list` to be specified as a JSON array of database names. The integration will auto-discover all the schemas, tables, and indexes in that database and collect metrics for all of them. This may lead to larger collection sizes.

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
