### PR TITLE
Add ability to gather lock metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ In order to use the PostgreSQL Integration it is required to configure `postgres
 
 You can view your data in Insights by creating your own custom NRQL queries. To do so, use the **PostgresqlInstanceSample**, **PostgressqlDatabaseSample**, **PostgresqlTableSample**,**PostgresqlIndexSample**, and **PgBouncerSample** event types.
 
+### Database Lock Metrics
+
+Collecting DB Lock Metrics requires that you first install the `tablefunc` extension on the `public` schema of the database you will be collecting lock metrics for. You can do so by:
+
+1. Installing the postgresql contribs package for your particular OS; and then
+2. Run the query `CREATE EXTENSION tablefunc;` against your database's public schema
+
+Afterwards, simply enable db lock collection by setting `collect_db_lock_metrics: true` in your nri-postgresql config file.
+
 ## Compatibility
 
 * Supported OS: No limitations

--- a/postgresql-config.yml.sample
+++ b/postgresql-config.yml.sample
@@ -32,6 +32,10 @@ instances:
       # Example: 
       # collection_list: '{"postgres":{"public":{"pg_table1":["pg_index1","pg_index2"],"pg_table2":[]}}}'
       collection_list: '["postgres"]'
+      # True if database lock metrics should be collected
+      # Note: requires that the `tablefunc` extension be installed on the public schema
+      # of the database where lock metrics will be collected.
+      collect_db_lock_metrics: false
       # True if SSL is to be used. Defaults to false.
       enable_ssl: true
       # True if the SSL certificate should be trusted without validating.

--- a/src/args/argument_list.go
+++ b/src/args/argument_list.go
@@ -19,6 +19,7 @@ type ArgumentList struct {
 	EnableSSL              bool   `default:"false" help:"If true will use SSL encryption, false will not use encryption"`
 	TrustServerCertificate bool   `default:"false" help:"If true server certificate is not verified for SSL. If false certificate will be verified against supplied certificate"`
 	Pgbouncer              bool   `default:"false" help:"Collects metrics from PgBouncer instance. Assumes connection is through PgBouncer."`
+	CollectDbLockMetrics   bool   `default:"false" help:"If true, enables collection of lock metrics for the specified database. (Note: requires that the 'tablefunc' extension is installed)"`
 	SSLRootCertLocation    string `default:"" help:"Absolute path to PEM encoded root certificate file"`
 	SSLCertLocation        string `default:"" help:"Absolute path to PEM encoded client cert file"`
 	SSLKeyLocation         string `default:"" help:"Absolute path to PEM encoded client key file"`

--- a/src/metrics/lock_definitions.go
+++ b/src/metrics/lock_definitions.go
@@ -1,0 +1,69 @@
+package metrics
+
+import (
+	"github.com/blang/semver"
+	"github.com/newrelic/nri-postgresql/src/collection"
+)
+
+func generateLockDefinitions(databases collection.DatabaseList, version *semver.Version) []*QueryDefinition {
+	queryDefinitions := make([]*QueryDefinition, 0, 1)
+	if len(databases) == 0 {
+		return queryDefinitions
+	}
+
+	queryDefinitions = append(queryDefinitions, lockDefinitions.insertDatabaseNames(databases))
+
+	return queryDefinitions
+}
+
+var lockDefinitions = &QueryDefinition{
+	query: `SELECT -- LOCKS_DEFINITION
+                 database,
+                 COALESCE(access_exclusive_lock, 0) AS access_exclusive_lock,
+                 COALESCE(access_share_lock, 0) AS access_share_lock,
+                 COALESCE(exclusive_lock, 0) AS exclusive_lock,
+                 COALESCE(row_exclusive_lock, 0) AS row_exclusive_lock,
+                 COALESCE(row_share_lock, 0) AS row_share_lock,
+                 COALESCE(share_lock, 0) AS share_lock,
+                 COALESCE(share_row_exclusive_lock, 0) AS share_row_exclusive_lock,
+                 COALESCE(share_update_exclusive_lock, 0) AS share_update_exclusive_lock
+            FROM public.crosstab(
+                  $$SELECT psa.datname AS database,
+                           lock.mode,
+                           count(lock.mode)
+                     FROM pg_locks AS lock
+                LEFT JOIN pg_stat_activity AS psa ON lock.pid = psa.pid
+                    WHERE psa.datname IN (%DATABASES%)
+                 GROUP BY lock.database, lock.mode, psa.datname
+                 ORDER BY database,mode$$,
+                 $$VALUES ('AccessExclusiveLock'::text),
+                          ('AccessShareLock'::text),
+                          ('ExclusiveLock'::text),
+                          ('RowExclusiveLock'::text),
+                          ('RowShareLock'::text),
+                          ('ShareLock'::text),
+                          ('ShareRowExclusiveLock'::text),
+                          ('ShareUpdateExclusiveLock'::text) $$
+           ) AS data (
+                 database text,
+                 access_exclusive_lock numeric,
+                 access_share_lock numeric,
+                 exclusive_lock numeric,
+                 row_exclusive_lock numeric,
+                 row_share_lock numeric,
+                 share_lock numeric,
+                 share_row_exclusive_lock numeric,
+                 share_update_exclusive_lock numeric
+          );`,
+	dataModels: []struct {
+		databaseBase
+		AccessExclusiveLock      *int `db:"access_exclusive_lock" metric_name:"db.locks.AccessExclusiveLock" source_type:"gauge"`
+		AccessShareLock          *int `db:"access_share_lock" metric_name:"db.locks.AccessShareLock" source_type:"gauge"`
+		ExclusiveLock            *int `db:"exclusive_lock" metric_name:"db.locks.ExclusiveLock" source_type:"gauge"`
+		RowExclusiveLock         *int `db:"row_exclusive_lock" metric_name:"db.locks.RowExclusiveLock" source_type:"gauge"`
+		RowShareLock             *int `db:"row_share_lock" metric_name:"db.locks.RowShareLock" source_type:"gauge"`
+		ShareLock                *int `db:"share_lock" metric_name:"db.locks.ShareLock" source_type:"gauge"`
+		ShareRowExclusiveLock    *int `db:"share_row_exclusive_lock" metric_name:"db.locks.ShareRowExclusiveLock" source_type:"gauge"`
+		ShareUpdateExclusiveLock *int `db:"share_update_exclusive_lock" metric_name:"db.locks.ShareUpdateExclusiveLock" source_type:"gauge"`
+	}{},
+}

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -17,7 +17,7 @@ const (
 )
 
 // PopulateMetrics collects metrics for each type
-func PopulateMetrics(ci connection.Info, databaseList collection.DatabaseList, instance *integration.Entity, i *integration.Integration, collectPgBouncer, CollectDbLocks bool) {
+func PopulateMetrics(ci connection.Info, databaseList collection.DatabaseList, instance *integration.Entity, i *integration.Integration, collectPgBouncer, collectDbLocks bool) {
 
 	con, err := ci.NewConnection(ci.DatabaseName())
 	if err != nil {
@@ -34,7 +34,7 @@ func PopulateMetrics(ci connection.Info, databaseList collection.DatabaseList, i
 
 	PopulateInstanceMetrics(instance, version, con)
 	PopulateDatabaseMetrics(databaseList, version, i, con, ci)
-	if CollectDbLocks {
+	if collectDbLocks {
 		PopulateDatabaseLockMetrics(databaseList, version, i, con, ci)
 	}
 	PopulateTableMetrics(databaseList, i, ci)

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -17,7 +17,7 @@ const (
 )
 
 // PopulateMetrics collects metrics for each type
-func PopulateMetrics(ci connection.Info, databaseList collection.DatabaseList, instance *integration.Entity, i *integration.Integration, collectPgBouncer bool) {
+func PopulateMetrics(ci connection.Info, databaseList collection.DatabaseList, instance *integration.Entity, i *integration.Integration, collectPgBouncer, CollectDbLocks bool) {
 
 	con, err := ci.NewConnection(ci.DatabaseName())
 	if err != nil {
@@ -34,9 +34,12 @@ func PopulateMetrics(ci connection.Info, databaseList collection.DatabaseList, i
 
 	PopulateInstanceMetrics(instance, version, con)
 	PopulateDatabaseMetrics(databaseList, version, i, con, ci)
-	PopulateDatabaseLockMetrics(databaseList, version, i, con, ci)
+	if CollectDbLocks {
+		PopulateDatabaseLockMetrics(databaseList, version, i, con, ci)
+	}
 	PopulateTableMetrics(databaseList, i, ci)
 	PopulateIndexMetrics(databaseList, i, ci)
+
 	if collectPgBouncer {
 		con, err = ci.NewConnection("pgbouncer")
 		if err != nil {

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -34,6 +34,7 @@ func PopulateMetrics(ci connection.Info, databaseList collection.DatabaseList, i
 
 	PopulateInstanceMetrics(instance, version, con)
 	PopulateDatabaseMetrics(databaseList, version, i, con, ci)
+	PopulateDatabaseLockMetrics(databaseList, version, i, con, ci)
 	PopulateTableMetrics(databaseList, i, ci)
 	PopulateIndexMetrics(databaseList, i, ci)
 	if collectPgBouncer {
@@ -117,8 +118,27 @@ func PopulateInstanceMetrics(instanceEntity *integration.Entity, version *semver
 // PopulateDatabaseMetrics populates the metrics for a database
 func PopulateDatabaseMetrics(databases collection.DatabaseList, version *semver.Version, pgIntegration *integration.Integration, connection *connection.PGSQLConnection, ci connection.Info) {
 	databaseDefinitions := generateDatabaseDefinitions(databases, version)
+	processDatabaseDefinitions(databaseDefinitions, pgIntegration, connection, ci)
+}
 
-	for _, queryDef := range databaseDefinitions {
+// PopulateDatabaseLockMetrics populates the lock metrics for a database
+func PopulateDatabaseLockMetrics(databases collection.DatabaseList, version *semver.Version, pgIntegration *integration.Integration, connection *connection.PGSQLConnection, ci connection.Info) {
+	if !connection.HaveExtensionInSchema("tablefunc", "public") {
+		log.Warn("Crosstab function not available; database lock metric gathering not possible.")
+		log.Warn("To enable database lock metrics, enable the 'tablefunc' extension on the public")
+		log.Warn("schema of your database. You can do so by:")
+		log.Warn("  1. Installing the postgresql contribs package for your OS; and")
+		log.Warn("  2. Run the query 'CREATE EXTENSION tablefunc;' against your database's public schema")
+		return
+	}
+
+	lockDefinitions := generateLockDefinitions(databases, version)
+
+	processDatabaseDefinitions(lockDefinitions, pgIntegration, connection, ci)
+}
+
+func processDatabaseDefinitions(definitions []*QueryDefinition, pgIntegration *integration.Integration, connection *connection.PGSQLConnection, ci connection.Info) {
+	for _, queryDef := range definitions {
 		// collect into model
 		dataModels := queryDef.GetDataModels()
 		if err := connection.Query(dataModels, queryDef.GetQuery()); err != nil {
@@ -232,11 +252,11 @@ func populateTableMetricsForDatabase(schemaList collection.SchemaList, con *conn
 func PopulateIndexMetrics(databases collection.DatabaseList, pgIntegration *integration.Integration, ci connection.Info) {
 	for database, schemaList := range databases {
 		con, err := ci.NewConnection(database)
-		defer con.Close()
 		if err != nil {
 			log.Error("Failed to create new connection to database %s: %s", database, err.Error())
 			continue
 		}
+		defer con.Close()
 		populateIndexMetricsForDatabase(schemaList, con, pgIntegration, ci)
 	}
 }

--- a/src/metrics/metrics_test.go
+++ b/src/metrics/metrics_test.go
@@ -130,6 +130,74 @@ func TestPopulateDatabaseMetrics(t *testing.T) {
 	assert.Equal(t, expected, dbEntity.Metrics[0].Metrics)
 }
 
+func TestPopulateDatabaseLockMetrics_WithTablefuncExtension(t *testing.T) {
+	testIntegration, _ := integration.New("test", "test")
+
+	version := semver.MustParse("9.0.0")
+	dbList := collection.DatabaseList{"test1": {}}
+
+	testConnection, mock := connection.CreateMockSQL(t)
+
+	extensionRows := sqlmock.NewRows([]string{
+		"schema",
+		"extension",
+	}).AddRow("public", "tablefunc")
+	mock.ExpectQuery(".*EXTENSIONS_LIST.*").WillReturnRows(extensionRows)
+
+	lockRows := sqlmock.NewRows([]string{
+		"database",
+		"access_exclusive_lock",
+		"access_share_lock",
+		"exclusive_lock",
+		"row_exclusive_lock",
+		"row_share_lock",
+		"share_lock",
+		"share_row_exclusive_lock",
+		"share_update_exclusive_lock",
+	}).AddRow("testDB", 1, 2, 3, 4, 5, 6, 7, 8)
+	mock.ExpectQuery(".*LOCKS_DEFINITION.*").WillReturnRows(lockRows)
+
+	ci := &connection.MockInfo{}
+	PopulateDatabaseLockMetrics(dbList, &version, testIntegration, testConnection, ci)
+
+	expected := map[string]interface{}{
+		"db.locks.AccessExclusiveLock":      float64(1),
+		"db.locks.AccessShareLock":          float64(2),
+		"db.locks.ExclusiveLock":            float64(3),
+		"db.locks.RowExclusiveLock":         float64(4),
+		"db.locks.RowShareLock":             float64(5),
+		"db.locks.ShareLock":                float64(6),
+		"db.locks.ShareRowExclusiveLock":    float64(7),
+		"db.locks.ShareUpdateExclusiveLock": float64(8),
+		"displayName":                       "testDB",
+		"entityName":                        "database:testDB",
+		"event_type":                        "PostgresqlDatabaseSample",
+	}
+
+	dbEntity, err := testIntegration.Entity("testDB", "pg-database", integration.NewIDAttribute("host", "testhost"), integration.NewIDAttribute("port", "1234"))
+
+	assert.Nil(t, err)
+	assert.Equal(t, expected, dbEntity.Metrics[0].Metrics)
+}
+
+func TestPopulateDatabaseLockMetrics_WithoutTablefuncExtension(t *testing.T) {
+	testIntegration, _ := integration.New("test", "test")
+
+	version := semver.MustParse("9.0.0")
+	dbList := collection.DatabaseList{"test1": {}}
+
+	testConnection, mock := connection.CreateMockSQL(t)
+	extensionRows := sqlmock.NewRows([]string{"schema", "extension"})
+	mock.ExpectQuery(".*EXTENSIONS_LIST.*").WillReturnRows(extensionRows)
+
+	ci := &connection.MockInfo{}
+	PopulateDatabaseLockMetrics(dbList, &version, testIntegration, testConnection, ci)
+	dbEntity, err := testIntegration.Entity("testDB", "pg-database", integration.NewIDAttribute("host", "testhost"), integration.NewIDAttribute("port", "1234"))
+
+	assert.Nil(t, err)
+	assert.Empty(t, dbEntity.Metrics)
+}
+
 func Test_populateTableMetricsForDatabase(t *testing.T) {
 	testIntegration, _ := integration.New("test", "test")
 

--- a/src/metrics/metrics_test.go
+++ b/src/metrics/metrics_test.go
@@ -503,6 +503,6 @@ func TestPopulateMetrics(t *testing.T) {
 
 	instance, _ := testIntegration.Entity("testInstance", "instance")
 
-	PopulateMetrics(ci, dbList, instance, testIntegration, true)
+	PopulateMetrics(ci, dbList, instance, testIntegration, true, true)
 
 }

--- a/src/postgresql.go
+++ b/src/postgresql.go
@@ -50,7 +50,7 @@ func main() {
 	}
 
 	if args.HasMetrics() {
-		metrics.PopulateMetrics(connectionInfo, collectionList, instance, postgresIntegration, args.Pgbouncer)
+		metrics.PopulateMetrics(connectionInfo, collectionList, instance, postgresIntegration, args.Pgbouncer, args.CollectDbLockMetrics)
 	}
 
 	if args.HasInventory() {


### PR DESCRIPTION
#### Description of the changes

Adds the ability to gather database lock metrics. The easiest method for doing so was to leverage the `crosstab` function of the `tablefunc` extension. If the extension is not available, a warning will be emitted alerting the user to that fact, and providing instructions on how to enable lock metric gather.

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
