### PR TITLE
feat: remove requirement for key and cert with ssl enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.4.2 (2020-07-29)
+### Fixed
+- Removed check for client-side certificate and key when enabling ssl. Server certificate and key are enough to create SSL connections
+
 ## 2.4.1 (2020-07-01)
 ### Fixed
 - Stats collection for newer pgbouncer version

--- a/src/args/argument_list.go
+++ b/src/args/argument_list.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	sdkArgs "github.com/newrelic/infra-integrations-sdk/args"
+	"github.com/newrelic/infra-integrations-sdk/log"
 )
 
 // ArgumentList struct that holds all PostgreSQL arguments
@@ -48,7 +49,7 @@ func (al ArgumentList) validateSSL() error {
 		}
 
 		if al.SSLCertLocation == "" || al.SSLKeyLocation == "" {
-			return errors.New("invalid configuration: must specify both a client cert and key file when enabling SSL")
+			log.Warn("potentially invalid configuration: client cert and/or key file not present when SSL is enabled")
 		}
 	}
 

--- a/src/args/argument_list_test.go
+++ b/src/args/argument_list_test.go
@@ -69,7 +69,7 @@ func TestValidate(t *testing.T) {
 				SSLCertLocation:        "my.crt",
 				CollectionList:         "{}",
 			},
-			true,
+			false,
 		},
 		{
 			"Missing Cert file with Key file",
@@ -84,7 +84,7 @@ func TestValidate(t *testing.T) {
 				SSLCertLocation:        "",
 				CollectionList:         "{}",
 			},
-			true,
+			false,
 		},
 	}
 

--- a/src/connection/pgsql_connection.go
+++ b/src/connection/pgsql_connection.go
@@ -176,8 +176,12 @@ func createConnectionURL(ci *connectionInfo, database string) string {
 
 // addSSLQueries add SSL query parameters
 func addSSLQueries(query url.Values, ci *connectionInfo) {
-	query.Add("sslcert", ci.SSLCertLocation)
-	query.Add("sslkey", ci.SSLKeyLocation)
+	if ci.SSLCertLocation != "" {
+		query.Add("sslcert", ci.SSLCertLocation)
+	}
+	if ci.SSLKeyLocation != "" {
+		query.Add("sslkey", ci.SSLKeyLocation)
+	}
 
 	if ci.TrustServerCertificate {
 		query.Add("sslmode", "require")

--- a/src/postgresql.go
+++ b/src/postgresql.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	integrationName    = "com.newrelic.postgresql"
-	integrationVersion = "2.4.1"
+	integrationVersion = "2.4.2"
 )
 
 func main() {


### PR DESCRIPTION
When connecting to the server using SSL a certificate file and key are not mandatory so we remove the process terminating check and only log a warning to help in debugging potential issues