### PR TITLE
Fix Index size metric with correct values

### DIFF
--- a/src/metrics/index_definitions.go
+++ b/src/metrics/index_definitions.go
@@ -49,7 +49,7 @@ var indexDefinition = &QueryDefinition{
 			FROM pg_tables t
 			LEFT OUTER JOIN pg_class c ON t.tablename=c.relname
 			LEFT OUTER JOIN
-					( SELECT c.relname AS ctablename, x.indrelid indexoid, ipg.relname AS indexname, x.indnatts AS number_of_columns, idx_scan, idx_tup_read, idx_tup_fetch, indexrelname, indisunique FROM pg_index x
+					( SELECT c.relname AS ctablename, x.indexrelid indexoid, ipg.relname AS indexname, x.indnatts AS number_of_columns, idx_scan, idx_tup_read, idx_tup_fetch, indexrelname, indisunique FROM pg_index x
 								 JOIN pg_class c ON c.oid = x.indrelid
 								 JOIN pg_class ipg ON ipg.oid = x.indexrelid
 								 JOIN pg_stat_all_indexes psai ON x.indexrelid = psai.indexrelid )


### PR DESCRIPTION
At my company we just used this to check a specific table in our database and noticed that the index_size was wrong.
Turns out the query used to pull that information is slightly off.

According to PostgreSQL docs https://www.postgresql.org/docs/current/catalog-pg-index.html
`indrelid` is `The OID of the pg_class entry for the table this index is for`
since the `indexoid` is used to calculate size by giving it as the parameter to `pg_relation_size`, that returns the size of the whole table and not just the index.

The fix is to use `indexrelid` which is `The OID of the pg_class entry for this index`.