### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.7.2 (2021-06-17)
+### Changed
+- Add `db.maxconnections` metric that collects the maximum number of concurrent connections to the database server.
+
+### Fixed
+- Index size metric now calculated using `indexrelid`, instead of `indrelid`.
+
 ## 2.7.1 (2021-06-10)
 ### Changed
 - Add ARM support.


### PR DESCRIPTION
### Changed
- Add `db.maxconnections` metric that collects the maximum number of concurrent connections to the database server.

### Fixed
- Index size metric now calculated using `indexrelid`, instead of `indrelid`.