### PR TITLE
Unmarshal postgresql integer values always to int64

### DIFF
--- a/src/metrics/database_definitions.go
+++ b/src/metrics/database_definitions.go
@@ -67,17 +67,17 @@ var databaseDefinitionUnder91 = &QueryDefinition{
 
 	dataModels: []struct {
 		databaseBase
-		MaxConnections         *int `db:"max_connections"          metric_name:"db.maxconnections"        source_type:"gauge"`
-		ActiveConnections      *int `db:"active_connections"       metric_name:"db.connections"           source_type:"gauge"`
-		TransactionsCommitted  *int `db:"transactions_committed"   metric_name:"db.commitsPerSecond"      source_type:"rate"`
-		TransactionsRolledBack *int `db:"transactions_rolled_back" metric_name:"db.rollbacksPerSecond"    source_type:"rate"`
-		BlockReads             *int `db:"block_reads"              metric_name:"db.readsPerSecond"        source_type:"rate"`
-		BufferHits             *int `db:"buffer_hits"              metric_name:"db.bufferHitsPerSecond"   source_type:"rate"`
-		RowsReturned           *int `db:"rows_returned"            metric_name:"db.rowsReturnedPerSecond" source_type:"rate"`
-		RowsFetched            *int `db:"rows_fetched"             metric_name:"db.rowsFetchedPerSecond"  source_type:"rate"`
-		RowsInserted           *int `db:"rows_inserted"            metric_name:"db.rowsInsertedPerSecond" source_type:"rate"`
-		RowsUpdated            *int `db:"rows_updated"             metric_name:"db.rowsUpdatedPerSecond"  source_type:"rate"`
-		RowsDeleted            *int `db:"rows_deleted"             metric_name:"db.rowsDeletedPerSecond"  source_type:"rate"`
+		MaxConnections         *int64 `db:"max_connections"          metric_name:"db.maxconnections"        source_type:"gauge"`
+		ActiveConnections      *int64 `db:"active_connections"       metric_name:"db.connections"           source_type:"gauge"`
+		TransactionsCommitted  *int64 `db:"transactions_committed"   metric_name:"db.commitsPerSecond"      source_type:"rate"`
+		TransactionsRolledBack *int64 `db:"transactions_rolled_back" metric_name:"db.rollbacksPerSecond"    source_type:"rate"`
+		BlockReads             *int64 `db:"block_reads"              metric_name:"db.readsPerSecond"        source_type:"rate"`
+		BufferHits             *int64 `db:"buffer_hits"              metric_name:"db.bufferHitsPerSecond"   source_type:"rate"`
+		RowsReturned           *int64 `db:"rows_returned"            metric_name:"db.rowsReturnedPerSecond" source_type:"rate"`
+		RowsFetched            *int64 `db:"rows_fetched"             metric_name:"db.rowsFetchedPerSecond"  source_type:"rate"`
+		RowsInserted           *int64 `db:"rows_inserted"            metric_name:"db.rowsInsertedPerSecond" source_type:"rate"`
+		RowsUpdated            *int64 `db:"rows_updated"             metric_name:"db.rowsUpdatedPerSecond"  source_type:"rate"`
+		RowsDeleted            *int64 `db:"rows_deleted"             metric_name:"db.rowsDeletedPerSecond"  source_type:"rate"`
 	}{},
 }
 
@@ -112,22 +112,22 @@ var databaseDefinitionOver91 = &QueryDefinition{
 
 	dataModels: []struct {
 		databaseBase
-		MaxConnections                    *int `db:"max_connections"                             metric_name:"db.maxconnections"                source_type:"gauge"`
-		ActiveConnections                 *int `db:"active_connections"                          metric_name:"db.connections"                   source_type:"gauge"`
-		TransactionsCommitted             *int `db:"transactions_committed"                      metric_name:"db.commitsPerSecond"              source_type:"rate"`
-		TransactionsRolledBack            *int `db:"transactions_rolled_back"                    metric_name:"db.rollbacksPerSecond"            source_type:"rate"`
-		BlockReads                        *int `db:"block_reads"                                 metric_name:"db.readsPerSecond"                source_type:"rate"`
-		BufferHits                        *int `db:"buffer_hits"                                 metric_name:"db.bufferHitsPerSecond"           source_type:"rate"`
-		RowsReturned                      *int `db:"rows_returned"                               metric_name:"db.rowsReturnedPerSecond"         source_type:"rate"`
-		RowsFetched                       *int `db:"rows_fetched"                                metric_name:"db.rowsFetchedPerSecond"          source_type:"rate"`
-		RowsInserted                      *int `db:"rows_inserted"                               metric_name:"db.rowsInsertedPerSecond"         source_type:"rate"`
-		RowsUpdated                       *int `db:"rows_updated"                                metric_name:"db.rowsUpdatedPerSecond"          source_type:"rate"`
-		RowsDeleted                       *int `db:"rows_deleted"                                metric_name:"db.rowsDeletedPerSecond"          source_type:"rate"`
-		CanceledQueriesDroppedTablespaces *int `db:"queries_canceled_due_to_dropped_tablespaces" metric_name:"db.conflicts.tablespacePerSecond" source_type:"rate"`
-		CanceledQueriesLockTimeouts       *int `db:"queries_canceled_due_to_lock_timeouts"       metric_name:"db.conflicts.locksPerSecond"      source_type:"rate"`
-		CanceledQueriesOldSnapshots       *int `db:"queries_canceled_due_to_old_snapshots"       metric_name:"db.conflicts.snapshotPerSecond"   source_type:"rate"`
-		CanceledQueriesPinnedBuffers      *int `db:"queries_canceled_due_to_pinned_buffers"      metric_name:"db.conflicts.bufferpinPerSecond"  source_type:"rate"`
-		CanceledQueriesDeadlocks          *int `db:"queries_canceled_due_to_deadlocks"           metric_name:"db.conflicts.deadlockPerSecond"   source_type:"rate"`
+		MaxConnections                    *int64 `db:"max_connections"                             metric_name:"db.maxconnections"                source_type:"gauge"`
+		ActiveConnections                 *int64 `db:"active_connections"                          metric_name:"db.connections"                   source_type:"gauge"`
+		TransactionsCommitted             *int64 `db:"transactions_committed"                      metric_name:"db.commitsPerSecond"              source_type:"rate"`
+		TransactionsRolledBack            *int64 `db:"transactions_rolled_back"                    metric_name:"db.rollbacksPerSecond"            source_type:"rate"`
+		BlockReads                        *int64 `db:"block_reads"                                 metric_name:"db.readsPerSecond"                source_type:"rate"`
+		BufferHits                        *int64 `db:"buffer_hits"                                 metric_name:"db.bufferHitsPerSecond"           source_type:"rate"`
+		RowsReturned                      *int64 `db:"rows_returned"                               metric_name:"db.rowsReturnedPerSecond"         source_type:"rate"`
+		RowsFetched                       *int64 `db:"rows_fetched"                                metric_name:"db.rowsFetchedPerSecond"          source_type:"rate"`
+		RowsInserted                      *int64 `db:"rows_inserted"                               metric_name:"db.rowsInsertedPerSecond"         source_type:"rate"`
+		RowsUpdated                       *int64 `db:"rows_updated"                                metric_name:"db.rowsUpdatedPerSecond"          source_type:"rate"`
+		RowsDeleted                       *int64 `db:"rows_deleted"                                metric_name:"db.rowsDeletedPerSecond"          source_type:"rate"`
+		CanceledQueriesDroppedTablespaces *int64 `db:"queries_canceled_due_to_dropped_tablespaces" metric_name:"db.conflicts.tablespacePerSecond" source_type:"rate"`
+		CanceledQueriesLockTimeouts       *int64 `db:"queries_canceled_due_to_lock_timeouts"       metric_name:"db.conflicts.locksPerSecond"      source_type:"rate"`
+		CanceledQueriesOldSnapshots       *int64 `db:"queries_canceled_due_to_old_snapshots"       metric_name:"db.conflicts.snapshotPerSecond"   source_type:"rate"`
+		CanceledQueriesPinnedBuffers      *int64 `db:"queries_canceled_due_to_pinned_buffers"      metric_name:"db.conflicts.bufferpinPerSecond"  source_type:"rate"`
+		CanceledQueriesDeadlocks          *int64 `db:"queries_canceled_due_to_deadlocks"           metric_name:"db.conflicts.deadlockPerSecond"   source_type:"rate"`
 	}{},
 }
 
@@ -150,10 +150,10 @@ var databaseDefinitionOver92 = &QueryDefinition{
 
 	dataModels: []struct {
 		databaseBase
-		TempFilesCreated   *int `db:"temporary_files_created" metric_name:"db.tempFilesCreatedPerSecond"        source_type:"rate"`
-		TempWrittenInBytes *int `db:"temporary_bytes_written" metric_name:"db.tempWrittenInBytesPerSecond"      source_type:"rate"`
-		Deadlocks          *int `db:"deadlocks"               metric_name:"db.deadlocksPerSecond"               source_type:"rate"`
-		TimeSpentReading   *int `db:"time_spent_reading_data" metric_name:"db.readTimeInMillisecondsPerSecond"  source_type:"rate"`
-		TimeSpentWriting   *int `db:"time_spent_writing_data" metric_name:"db.writeTimeInMillisecondsPerSecond" source_type:"rate"`
+		TempFilesCreated   *int64 `db:"temporary_files_created" metric_name:"db.tempFilesCreatedPerSecond"        source_type:"rate"`
+		TempWrittenInBytes *int64 `db:"temporary_bytes_written" metric_name:"db.tempWrittenInBytesPerSecond"      source_type:"rate"`
+		Deadlocks          *int64 `db:"deadlocks"               metric_name:"db.deadlocksPerSecond"               source_type:"rate"`
+		TimeSpentReading   *int64 `db:"time_spent_reading_data" metric_name:"db.readTimeInMillisecondsPerSecond"  source_type:"rate"`
+		TimeSpentWriting   *int64 `db:"time_spent_writing_data" metric_name:"db.writeTimeInMillisecondsPerSecond" source_type:"rate"`
 	}{},
 }

--- a/src/metrics/index_definitions.go
+++ b/src/metrics/index_definitions.go
@@ -63,8 +63,8 @@ var indexDefinition = &QueryDefinition{
 		schemaBase
 		tableBase
 		indexBase
-		IndexSize   *int `db:"index_size"     metric_name:"index.sizeInBytes"          source_type:"gauge"`
-		RowsRead    *int `db:"tuples_read"    metric_name:"index.rowsReadPerSecond"    source_type:"rate"`
-		RowsFetched *int `db:"tuples_fetched" metric_name:"index.rowsFetchedPerSecond" source_type:"rate"`
+		IndexSize   *int64 `db:"index_size"     metric_name:"index.sizeInBytes"          source_type:"gauge"`
+		RowsRead    *int64 `db:"tuples_read"    metric_name:"index.rowsReadPerSecond"    source_type:"rate"`
+		RowsFetched *int64 `db:"tuples_fetched" metric_name:"index.rowsFetchedPerSecond" source_type:"rate"`
 	}{},
 }

--- a/src/metrics/instance_definitions.go
+++ b/src/metrics/instance_definitions.go
@@ -34,13 +34,13 @@ var instanceDefinitionBase = &QueryDefinition{
 		FROM pg_stat_bgwriter BG;`,
 
 	dataModels: []struct {
-		ScheduledCheckpointsPerformed    *int `db:"scheduled_checkpoints_performed"      metric_name:"bgwriter.checkpointsScheduledPerSecond"             source_type:"rate"`
-		RequestedCheckpointsPerformed    *int `db:"requested_checkpoints_performed"      metric_name:"bgwriter.checkpointsRequestedPerSecond"             source_type:"rate"`
-		BuffersWrittenDuringCheckpoint   *int `db:"buffers_written_during_checkpoint"    metric_name:"bgwriter.buffersWrittenForCheckpointsPerSecond"     source_type:"rate"`
-		BuffersWrittenByBackgroundWriter *int `db:"buffers_written_by_background_writer" metric_name:"bgwriter.buffersWrittenByBackgroundWriterPerSecond" source_type:"rate"`
-		BackgroundWriterStops            *int `db:"background_writer_stops"              metric_name:"bgwriter.backgroundWriterStopsPerSecond"            source_type:"rate"`
-		BuffersWrittenByBackend          *int `db:"buffers_written_by_backend"           metric_name:"bgwriter.buffersWrittenByBackendPerSecond"          source_type:"rate"`
-		BuffersAllocated                 *int `db:"buffers_allocated"                    metric_name:"bgwriter.buffersAllocatedPerSecond"                 source_type:"rate"`
+		ScheduledCheckpointsPerformed    *int64 `db:"scheduled_checkpoints_performed"      metric_name:"bgwriter.checkpointsScheduledPerSecond"             source_type:"rate"`
+		RequestedCheckpointsPerformed    *int64 `db:"requested_checkpoints_performed"      metric_name:"bgwriter.checkpointsRequestedPerSecond"             source_type:"rate"`
+		BuffersWrittenDuringCheckpoint   *int64 `db:"buffers_written_during_checkpoint"    metric_name:"bgwriter.buffersWrittenForCheckpointsPerSecond"     source_type:"rate"`
+		BuffersWrittenByBackgroundWriter *int64 `db:"buffers_written_by_background_writer" metric_name:"bgwriter.buffersWrittenByBackgroundWriterPerSecond" source_type:"rate"`
+		BackgroundWriterStops            *int64 `db:"background_writer_stops"              metric_name:"bgwriter.backgroundWriterStopsPerSecond"            source_type:"rate"`
+		BuffersWrittenByBackend          *int64 `db:"buffers_written_by_backend"           metric_name:"bgwriter.buffersWrittenByBackendPerSecond"          source_type:"rate"`
+		BuffersAllocated                 *int64 `db:"buffers_allocated"                    metric_name:"bgwriter.buffersAllocatedPerSecond"                 source_type:"rate"`
 	}{},
 }
 
@@ -50,7 +50,7 @@ var instanceDefinition91 = &QueryDefinition{
 		FROM pg_stat_bgwriter BG;`,
 
 	dataModels: []struct {
-		BackendExecutedOwnFsync *int `db:"times_backend_executed_own_fsync" metric_name:"bgwriter.backendFsyncCallsPerSecond" source_type:"rate"`
+		BackendExecutedOwnFsync *int64 `db:"times_backend_executed_own_fsync" metric_name:"bgwriter.backendFsyncCallsPerSecond" source_type:"rate"`
 	}{},
 }
 
@@ -61,7 +61,7 @@ var instanceDefinition92 = &QueryDefinition{
 		FROM pg_stat_bgwriter BG;`,
 
 	dataModels: []struct {
-		CheckpointWriteTime *int `db:"time_writing_checkpoint_files_to_disk"       metric_name:"bgwriter.checkpointWriteTimeInMillisecondsPerSecond" source_type:"rate"`
-		CheckpointSynTime   *int `db:"time_synchronizing_checkpoint_files_to_disk" metric_name:"bgwriter.checkpointSyncTimeInMillisecondsPerSecond"  source_type:"rate"`
+		CheckpointWriteTime *int64 `db:"time_writing_checkpoint_files_to_disk"       metric_name:"bgwriter.checkpointWriteTimeInMillisecondsPerSecond" source_type:"rate"`
+		CheckpointSynTime   *int64 `db:"time_synchronizing_checkpoint_files_to_disk" metric_name:"bgwriter.checkpointSyncTimeInMillisecondsPerSecond"  source_type:"rate"`
 	}{},
 }

--- a/src/metrics/lock_definitions.go
+++ b/src/metrics/lock_definitions.go
@@ -56,13 +56,13 @@ var lockDefinitions = &QueryDefinition{
           );`,
 	dataModels: []struct {
 		databaseBase
-		AccessExclusiveLock      *int `db:"access_exclusive_lock" metric_name:"db.locks.accessExclusiveLock" source_type:"gauge"`
-		AccessShareLock          *int `db:"access_share_lock" metric_name:"db.locks.accessShareLock" source_type:"gauge"`
-		ExclusiveLock            *int `db:"exclusive_lock" metric_name:"db.locks.exclusiveLock" source_type:"gauge"`
-		RowExclusiveLock         *int `db:"row_exclusive_lock" metric_name:"db.locks.rowExclusiveLock" source_type:"gauge"`
-		RowShareLock             *int `db:"row_share_lock" metric_name:"db.locks.rowShareLock" source_type:"gauge"`
-		ShareLock                *int `db:"share_lock" metric_name:"db.locks.shareLock" source_type:"gauge"`
-		ShareRowExclusiveLock    *int `db:"share_row_exclusive_lock" metric_name:"db.locks.shareRowExclusiveLock" source_type:"gauge"`
-		ShareUpdateExclusiveLock *int `db:"share_update_exclusive_lock" metric_name:"db.locks.shareUpdateExclusiveLock" source_type:"gauge"`
+		AccessExclusiveLock      *int64 `db:"access_exclusive_lock" metric_name:"db.locks.accessExclusiveLock" source_type:"gauge"`
+		AccessShareLock          *int64 `db:"access_share_lock" metric_name:"db.locks.accessShareLock" source_type:"gauge"`
+		ExclusiveLock            *int64 `db:"exclusive_lock" metric_name:"db.locks.exclusiveLock" source_type:"gauge"`
+		RowExclusiveLock         *int64 `db:"row_exclusive_lock" metric_name:"db.locks.rowExclusiveLock" source_type:"gauge"`
+		RowShareLock             *int64 `db:"row_share_lock" metric_name:"db.locks.rowShareLock" source_type:"gauge"`
+		ShareLock                *int64 `db:"share_lock" metric_name:"db.locks.shareLock" source_type:"gauge"`
+		ShareRowExclusiveLock    *int64 `db:"share_row_exclusive_lock" metric_name:"db.locks.shareRowExclusiveLock" source_type:"gauge"`
+		ShareUpdateExclusiveLock *int64 `db:"share_update_exclusive_lock" metric_name:"db.locks.shareUpdateExclusiveLock" source_type:"gauge"`
 	}{},
 }

--- a/src/metrics/pgbouncer_definitions.go
+++ b/src/metrics/pgbouncer_definitions.go
@@ -13,23 +13,23 @@ var pgbouncerStatsDefinition = &QueryDefinition{
 
 	dataModels: []struct {
 		databaseBase
-		TotalXactCount  *int `db:"total_xact_count"  metric_name:"pgbouncer.stats.transactionsPerSecond"                           source_type:"rate"`
-		TotalQueryCount *int `db:"total_query_count" metric_name:"pgbouncer.stats.queriesPerSecond"                                source_type:"rate"`
-		TotalReceived   *int `db:"total_received"    metric_name:"pgbouncer.stats.bytesInPerSecond"                                source_type:"rate"`
-		TotalSent       *int `db:"total_sent"        metric_name:"pgbouncer.stats.bytesOutPerSecond"                               source_type:"rate"`
-		TotalXactTime   *int `db:"total_xact_time"   metric_name:"pgbouncer.stats.totalTransactionDurationInMillisecondsPerSecond" source_type:"rate"`
-		TotalQueryTime  *int `db:"total_query_time"  metric_name:"pgbouncer.stats.totalQueryDurationInMillisecondsPerSecond"       source_type:"rate"`
-		TotalRequests   *int `db:"total_requests"    metric_name:"pgbouncer.stats.requestsPerSecond"                               source_type:"rate"`
-		TotalWaitTime   *int `db:"total_wait_time"`
-		AvgXactCount    *int `db:"avg_xact_count"    metric_name:"pgbouncer.stats.avgTransactionCount"                             source_type:"gauge"`
-		AvgXactTime     *int `db:"avg_xact_time"     metric_name:"pgbouncer.stats.avgTransactionDurationInMilliseconds"            source_type:"gauge"`
-		AvgQueryCount   *int `db:"avg_query_count"   metric_name:"pgbouncer.stats.avgQueryCount"                                   source_type:"gauge"`
-		AvgRecv         *int `db:"avg_recv"          metric_name:"pgbouncer.stats.avgBytesIn"                                      source_type:"gauge"`
-		AvgSent         *int `db:"avg_sent"          metric_name:"pgbouncer.stats.avgBytesOut"                                     source_type:"gauge"`
-		AvgReq          *int `db:"avg_req"           metric_name:"pgbouncer.stats.avgRequestsPerSecond"                            source_type:"gauge"`
-		AvgQueryTime    *int `db:"avg_query_time"    metric_name:"pgbouncer.stats.avgQueryDurationInMilliseconds"                  source_type:"gauge"`
-		AvgQuery        *int `db:"avg_query"         metric_name:"pgbouncer.stats.avgQueryDurationInMilliseconds"                  source_type:"gauge"`
-		AvgWaitTime     *int `db:"avg_wait_time"`
+		TotalXactCount  *int64 `db:"total_xact_count"  metric_name:"pgbouncer.stats.transactionsPerSecond"                           source_type:"rate"`
+		TotalQueryCount *int64 `db:"total_query_count" metric_name:"pgbouncer.stats.queriesPerSecond"                                source_type:"rate"`
+		TotalReceived   *int64 `db:"total_received"    metric_name:"pgbouncer.stats.bytesInPerSecond"                                source_type:"rate"`
+		TotalSent       *int64 `db:"total_sent"        metric_name:"pgbouncer.stats.bytesOutPerSecond"                               source_type:"rate"`
+		TotalXactTime   *int64 `db:"total_xact_time"   metric_name:"pgbouncer.stats.totalTransactionDurationInMillisecondsPerSecond" source_type:"rate"`
+		TotalQueryTime  *int64 `db:"total_query_time"  metric_name:"pgbouncer.stats.totalQueryDurationInMillisecondsPerSecond"       source_type:"rate"`
+		TotalRequests   *int64 `db:"total_requests"    metric_name:"pgbouncer.stats.requestsPerSecond"                               source_type:"rate"`
+		TotalWaitTime   *int64 `db:"total_wait_time"`
+		AvgXactCount    *int64 `db:"avg_xact_count"    metric_name:"pgbouncer.stats.avgTransactionCount"                             source_type:"gauge"`
+		AvgXactTime     *int64 `db:"avg_xact_time"     metric_name:"pgbouncer.stats.avgTransactionDurationInMilliseconds"            source_type:"gauge"`
+		AvgQueryCount   *int64 `db:"avg_query_count"   metric_name:"pgbouncer.stats.avgQueryCount"                                   source_type:"gauge"`
+		AvgRecv         *int64 `db:"avg_recv"          metric_name:"pgbouncer.stats.avgBytesIn"                                      source_type:"gauge"`
+		AvgSent         *int64 `db:"avg_sent"          metric_name:"pgbouncer.stats.avgBytesOut"                                     source_type:"gauge"`
+		AvgReq          *int64 `db:"avg_req"           metric_name:"pgbouncer.stats.avgRequestsPerSecond"                            source_type:"gauge"`
+		AvgQueryTime    *int64 `db:"avg_query_time"    metric_name:"pgbouncer.stats.avgQueryDurationInMilliseconds"                  source_type:"gauge"`
+		AvgQuery        *int64 `db:"avg_query"         metric_name:"pgbouncer.stats.avgQueryDurationInMilliseconds"                  source_type:"gauge"`
+		AvgWaitTime     *int64 `db:"avg_wait_time"`
 	}{},
 }
 
@@ -39,15 +39,15 @@ var pgbouncerPoolsDefinition = &QueryDefinition{
 	dataModels: []struct {
 		databaseBase
 		User      *string `db:"user"`
-		ClActive  *int    `db:"cl_active"  metric_name:"pgbouncer.pools.clientConnectionsActive"  source_type:"gauge"`
-		ClWaiting *int    `db:"cl_waiting" metric_name:"pgbouncer.pools.clientConnectionsWaiting" source_type:"gauge"`
-		SvActive  *int    `db:"sv_active"  metric_name:"pgbouncer.pools.serverConnectionsActive"  source_type:"gauge"`
-		SvIdle    *int    `db:"sv_idle"    metric_name:"pgbouncer.pools.serverConnectionsIdle"    source_type:"gauge"`
-		SvUsed    *int    `db:"sv_used"    metric_name:"pgbouncer.pools.serverConnectionsUsed"    source_type:"gauge"`
-		SvTested  *int    `db:"sv_tested"  metric_name:"pgbouncer.pools.serverConnectionsTested"  source_type:"gauge"`
-		SvLogin   *int    `db:"sv_login"   metric_name:"pgbouncer.pools.serverConnectionsLogin"   source_type:"gauge"`
-		MaxWait   *int    `db:"maxwait"    metric_name:"pgbouncer.pools.maxwaitInMilliseconds"    source_type:"gauge"`
-		MaxWaitUs *int    `db:"maxwait_us"`
+		ClActive  *int64  `db:"cl_active"  metric_name:"pgbouncer.pools.clientConnectionsActive"  source_type:"gauge"`
+		ClWaiting *int64  `db:"cl_waiting" metric_name:"pgbouncer.pools.clientConnectionsWaiting" source_type:"gauge"`
+		SvActive  *int64  `db:"sv_active"  metric_name:"pgbouncer.pools.serverConnectionsActive"  source_type:"gauge"`
+		SvIdle    *int64  `db:"sv_idle"    metric_name:"pgbouncer.pools.serverConnectionsIdle"    source_type:"gauge"`
+		SvUsed    *int64  `db:"sv_used"    metric_name:"pgbouncer.pools.serverConnectionsUsed"    source_type:"gauge"`
+		SvTested  *int64  `db:"sv_tested"  metric_name:"pgbouncer.pools.serverConnectionsTested"  source_type:"gauge"`
+		SvLogin   *int64  `db:"sv_login"   metric_name:"pgbouncer.pools.serverConnectionsLogin"   source_type:"gauge"`
+		MaxWait   *int64  `db:"maxwait"    metric_name:"pgbouncer.pools.maxwaitInMilliseconds"    source_type:"gauge"`
+		MaxWaitUs *int64  `db:"maxwait_us"`
 		PoolMode  *string `db:"pool_mode"`
 	}{},
 }

--- a/src/metrics/table_definitions.go
+++ b/src/metrics/table_definitions.go
@@ -88,18 +88,18 @@ var tableDefinition = &QueryDefinition{
 		databaseBase
 		schemaBase
 		tableBase
-		TotalSize                *int     `db:"pg_total_relation_size" metric_name:"table.totalSizeInBytes"                   source_type:"gauge"`
-		IndexSize                *int     `db:"pg_indexes_size"        metric_name:"table.indexSizeInBytes"                   source_type:"gauge"`
-		LiveRows                 *int     `db:"n_live_tup"             metric_name:"table.liveRows"                           source_type:"gauge"`
-		DeadRows                 *int     `db:"n_dead_tup"             metric_name:"table.deadRows"                           source_type:"gauge"`
+		TotalSize                *int64   `db:"pg_total_relation_size" metric_name:"table.totalSizeInBytes"                   source_type:"gauge"`
+		IndexSize                *int64   `db:"pg_indexes_size"        metric_name:"table.indexSizeInBytes"                   source_type:"gauge"`
+		LiveRows                 *int64   `db:"n_live_tup"             metric_name:"table.liveRows"                           source_type:"gauge"`
+		DeadRows                 *int64   `db:"n_dead_tup"             metric_name:"table.deadRows"                           source_type:"gauge"`
 		IndexBlocksReadPerSecond *float32 `db:"idx_blks_read"          metric_name:"table.indexBlocksReadPerSecond"           source_type:"rate"`
 		IndexBlocksHitPerSecond  *float32 `db:"idx_blks_hit"           metric_name:"table.indexBlocksHitPerSecond"            source_type:"rate"`
 		ToastBlocksReadPerSecond *float32 `db:"toast_blks_read"        metric_name:"table.indexToastBlocksReadPerSecond"      source_type:"rate"`
 		ToastBlocksHitPerSecond  *float32 `db:"toast_blks_hit"         metric_name:"table.indexToastBlocksHitPerSecond"       source_type:"rate"`
-		LastVacuum               *int     `db:"last_vacuum"            metric_name:"table.lastVacuum"                         source_type:"gauge"`
-		LastAutoVacuum           *int     `db:"last_autovacuum"        metric_name:"table.lastAutoVacuum"                     source_type:"gauge"`
-		LastAnalyze              *int     `db:"last_analyze"           metric_name:"table.lastAnalyze"                        source_type:"gauge"`
-		LastAutoAnalyze          *int     `db:"last_autoanalyze"       metric_name:"table.lastAutoAnalyze"                    source_type:"gauge"`
+		LastVacuum               *int64   `db:"last_vacuum"            metric_name:"table.lastVacuum"                         source_type:"gauge"`
+		LastAutoVacuum           *int64   `db:"last_autovacuum"        metric_name:"table.lastAutoVacuum"                     source_type:"gauge"`
+		LastAnalyze              *int64   `db:"last_analyze"           metric_name:"table.lastAnalyze"                        source_type:"gauge"`
+		LastAutoAnalyze          *int64   `db:"last_autoanalyze"       metric_name:"table.lastAutoAnalyze"                    source_type:"gauge"`
 		SeqScans                 *float32 `db:"seq_scan"               metric_name:"table.sequentialScansPerSecond"           source_type:"rate"`
 		SeqReads                 *float32 `db:"seq_tup_read"           metric_name:"table.sequentialScanRowsFetchedPerSecond" source_type:"rate"`
 		IndexScans               *float32 `db:"idx_scan"               metric_name:"table.indexScansPerSecond"                source_type:"rate"`


### PR DESCRIPTION
Unmarshal postgresql integer values always to int64. 
We do this because on 32 bit machines, when the number from postgres exceeds 32 bit, the SQL driver reflects it to int64 but the destiny attribute is int(32).