### PR TITLE
Fix quotes around password value

### DIFF
--- a/postgresql-config.yml.sample
+++ b/postgresql-config.yml.sample
@@ -4,7 +4,7 @@ integrations:
     # The username for the postgres instance. Required.
     USERNAME: postgres
     # The password for the postgres instance. Required.
-    PASSWORD: pass
+    PASSWORD: 'pass'
 
     # The hostname for the postgres instance. Defaults to localhost.
     HOSTNAME: psql-sample.localnet


### PR DESCRIPTION
Special characters in YAML require quotes around the string. This change updates the sample config to include quotes.