### PR TITLE
Custom query ConfigMap examples

### DIFF
--- a/postgresql-config-multiple-custom-queries.yml.k8s_sample
+++ b/postgresql-config-multiple-custom-queries.yml.k8s_sample
@@ -1,0 +1,37 @@
+# This example configuration for the newrelic-infrastructure Helm chart assumes you are configuring the nri-bundle chart values. 
+# Prerequisite: apply the ConfigMap with `kubectl apply -f postgresql-custom-query.yml.k8s_sample`
+newrelic-infrastructure:
+  enabled: true
+  kubelet:
+    extraVolumeMounts:
+    - mountPath: /config
+      name: psql-vol
+    extraVolumes:
+    - name: psql-vol
+      configMap:
+        name: psql-config
+  integrations:
+    postgresql-config.yml:    
+      discovery:
+        command:
+          exec: /var/db/newrelic-infra/nri-discovery-kubernetes
+          match:
+            label.app.kubernetes.io/name: postgresql
+      integrations:
+        - name: nri-postgresql
+          env:
+            COLLECT_DB_LOCK_METRICS: false
+            COLLECTION_LIST: all
+            CUSTOM_METRICS_CONFIG: /config/postgresql-custom-query.yml
+            DATABASE: postgres
+            HOSTNAME: ${discovery.ip}
+            #HOSTNAME: psql-sample.localnet
+            PORT: 5432
+            USERNAME: postgres
+            PASSWORD: mypass
+            TIMEOUT: 10
+          interval: 15s
+          inventory_source: config/postgresql
+          labels:
+            env: production
+            role: postgresql

--- a/postgresql-custom-query.yml.k8s_sample
+++ b/postgresql-custom-query.yml.k8s_sample
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: psql-config
+  namespace: newrelic
+data:
+  postgresql-custom-query.yml: |
+    queries:
+
+    - query: >-
+        SELECT
+        BG.checkpoints_timed AS scheduled_checkpoints_performed,
+        BG.checkpoints_req AS requested_checkpoints_performed,
+        BG.buffers_checkpoint AS buffers_written_during_checkpoint,
+        BG.buffers_clean AS buffers_written_by_background_writer,
+        BG.maxwritten_clean AS background_writer_stops,
+        BG.buffers_backend AS buffers_written_by_backend,
+        BG.buffers_alloc AS buffers_allocated
+        FROM pg_stat_bgwriter BG;
+
+      metric_types:
+        buffers_allocated: rate
+
+      sample_name: MyCustomSample
+
+    - query: >-
+        SELECT
+        BG.checkpoints_timed AS scheduled_checkpoints_performed,
+        BG.checkpoints_req AS requested_checkpoints_performed,
+        BG.buffers_checkpoint AS buffers_written_during_checkpoint,
+        BG.buffers_clean AS buffers_written_by_background_writer,
+        BG.maxwritten_clean AS background_writer_stops,
+        BG.buffers_backend AS buffers_written_by_backend,
+        BG.buffers_alloc AS buffers_allocated
+        FROM pg_stat_bgwriter BG;
+
+      metric_types:
+        buffers_allocated: rate
+
+      sample_name: MyCustomSampleToo


### PR DESCRIPTION
This PR adds two YML examples - one for `newrelic-infrastructure` chart settings to include a `ConfigMap` for a custom query file, and one to add the `ConfigMap` resource itself.

This is to provide a workaround for multiple custom queries, when running `nri-postgresql` on Kubernetes.