### PR TITLE
Add pools metrics from pgbouncer v1.18 (NR-141120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### enhancement
+- Adds support for pgbouncer v18 and new metrics:`pgbouncer.pools.clientConnectionsWaitingCancelReq`,`pgbouncer.pools.clientConnectionsActiveCancelReq`,`pgbouncer.pools.serverConnectionsActiveCancel`,`pgbouncer.pools.serverConnectionsBeingCancel`,`pgbouncer.pools.serverConnectionsActive`
+
 ## v2.11.0 - 2023-06-02
 
 ### 🚀 Enhancements

--- a/src/metrics/metrics_test.go
+++ b/src/metrics/metrics_test.go
@@ -435,57 +435,13 @@ func Test_populateIndexMetricsForDatabase_noIndexes(t *testing.T) {
 }
 
 func TestPopulatePgBouncerMetrics(t *testing.T) {
-
-	pgbouncerStatsRows := sqlmock.NewRows([]string{
-		"database",
-		"total_xact_count",
-		"total_query_count",
-		"total_received",
-		"total_sent",
-		"total_xact_time",
-		"total_query_time",
-		"total_wait_time",
-		"avg_xact_count",
-		"avg_xact_time",
-		"avg_query_count",
-		"avg_recv",
-		"avg_sent",
-		"avg_query_time",
-		"avg_wait_time",
-	}).AddRow("testDB", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14)
-
-	expectedStats := map[string]interface{}{
-		"pgbouncer.stats.transactionsPerSecond":                           float64(0),
-		"pgbouncer.stats.queriesPerSecond":                                float64(0),
-		"pgbouncer.stats.bytesInPerSecond":                                float64(0),
-		"pgbouncer.stats.bytesOutPerSecond":                               float64(0),
-		"pgbouncer.stats.totalTransactionDurationInMillisecondsPerSecond": float64(0),
-		"pgbouncer.stats.totalQueryDurationInMillisecondsPerSecond":       float64(0),
-		"pgbouncer.stats.avgTransactionCount":                             float64(8),
-		"pgbouncer.stats.avgTransactionDurationInMilliseconds":            float64(9),
-		"pgbouncer.stats.avgQueryCount":                                   float64(10),
-		"pgbouncer.stats.avgBytesIn":                                      float64(11),
-		"pgbouncer.stats.avgBytesOut":                                     float64(12),
-		"pgbouncer.stats.avgQueryDurationInMilliseconds":                  float64(13),
-
-		"displayName": "testDB",
-		"entityName":  "pgbouncer:testDB",
-		"event_type":  "PgBouncerSample",
-		"host":        "testhost",
-	}
-
 	testsCases := []struct {
-		name string
-		// using a copy since sqlmock gets modified.
-		pgbouncerStatsRows sqlmock.Rows
+		name               string
 		pgbouncerPoolsRows *sqlmock.Rows
-
-		expectedStats map[string]interface{}
-		expectedPool  map[string]interface{}
+		expectedPool       map[string]interface{}
 	}{
 		{
-			name:               "pgbouncer version =< 15",
-			pgbouncerStatsRows: *pgbouncerStatsRows,
+			name: "pgbouncer version =< 15",
 			pgbouncerPoolsRows: sqlmock.NewRows([]string{
 				"database",
 				"user",
@@ -500,7 +456,6 @@ func TestPopulatePgBouncerMetrics(t *testing.T) {
 				"maxwait_us",
 				"pool_mode",
 			}).AddRow("testDB", "testUser", 1, 2, 3, 4, 5, 6, 7, 8, 9, "testMode"),
-			expectedStats: expectedStats,
 			expectedPool: map[string]interface{}{
 				"pgbouncer.pools.clientConnectionsActive":  float64(1),
 				"pgbouncer.pools.clientConnectionsWaiting": float64(2),
@@ -517,8 +472,7 @@ func TestPopulatePgBouncerMetrics(t *testing.T) {
 			},
 		},
 		{
-			name:               "pgbouncer version 16,17",
-			pgbouncerStatsRows: *pgbouncerStatsRows,
+			name: "pgbouncer version 16,17",
 			pgbouncerPoolsRows: sqlmock.NewRows([]string{
 				"database",
 				"user",
@@ -534,7 +488,6 @@ func TestPopulatePgBouncerMetrics(t *testing.T) {
 				"pool_mode",
 				"cl_cancel_req", // Added column.
 			}).AddRow("testDB", "testUser", 1, 2, 3, 4, 5, 6, 7, 8, 9, "testMode", 10),
-			expectedStats: expectedStats,
 			expectedPool: map[string]interface{}{
 				"pgbouncer.pools.clientConnectionsActive":    float64(1),
 				"pgbouncer.pools.clientConnectionsWaiting":   float64(2),
@@ -552,8 +505,7 @@ func TestPopulatePgBouncerMetrics(t *testing.T) {
 			},
 		},
 		{
-			name:               "pgbouncer version => 18",
-			pgbouncerStatsRows: *pgbouncerStatsRows,
+			name: "pgbouncer version => 18",
 			pgbouncerPoolsRows: sqlmock.NewRows([]string{
 				"database",
 				"user",
@@ -572,7 +524,6 @@ func TestPopulatePgBouncerMetrics(t *testing.T) {
 				"sv_active_cancel",
 				"sv_being_canceled",
 			}).AddRow("testDB", "testUser", 1, 2, 3, 4, 5, 6, 7, 8, 9, "testMode", 10, 11, 12, 13),
-			expectedStats: expectedStats,
 			expectedPool: map[string]interface{}{
 				"pgbouncer.pools.clientConnectionsActive":           float64(1),
 				"pgbouncer.pools.clientConnectionsWaiting":          float64(2),
@@ -602,8 +553,46 @@ func TestPopulatePgBouncerMetrics(t *testing.T) {
 
 			testConnection, mock := connection.CreateMockSQL(t)
 
+			pgbouncerStatsRows := sqlmock.NewRows([]string{
+				"database",
+				"total_xact_count",
+				"total_query_count",
+				"total_received",
+				"total_sent",
+				"total_xact_time",
+				"total_query_time",
+				"total_wait_time",
+				"avg_xact_count",
+				"avg_xact_time",
+				"avg_query_count",
+				"avg_recv",
+				"avg_sent",
+				"avg_query_time",
+				"avg_wait_time",
+			}).AddRow("testDB", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14)
+
+			expectedStats := map[string]interface{}{
+				"pgbouncer.stats.transactionsPerSecond":                           float64(0),
+				"pgbouncer.stats.queriesPerSecond":                                float64(0),
+				"pgbouncer.stats.bytesInPerSecond":                                float64(0),
+				"pgbouncer.stats.bytesOutPerSecond":                               float64(0),
+				"pgbouncer.stats.totalTransactionDurationInMillisecondsPerSecond": float64(0),
+				"pgbouncer.stats.totalQueryDurationInMillisecondsPerSecond":       float64(0),
+				"pgbouncer.stats.avgTransactionCount":                             float64(8),
+				"pgbouncer.stats.avgTransactionDurationInMilliseconds":            float64(9),
+				"pgbouncer.stats.avgQueryCount":                                   float64(10),
+				"pgbouncer.stats.avgBytesIn":                                      float64(11),
+				"pgbouncer.stats.avgBytesOut":                                     float64(12),
+				"pgbouncer.stats.avgQueryDurationInMilliseconds":                  float64(13),
+
+				"displayName": "testDB",
+				"entityName":  "pgbouncer:testDB",
+				"event_type":  "PgBouncerSample",
+				"host":        "testhost",
+			}
+
 			mock.ExpectQuery("SHOW STATS;").
-				WillReturnRows(&testCase.pgbouncerStatsRows)
+				WillReturnRows(pgbouncerStatsRows)
 			mock.ExpectQuery("SHOW POOLS;").
 				WillReturnRows(testCase.pgbouncerPoolsRows)
 
@@ -614,7 +603,7 @@ func TestPopulatePgBouncerMetrics(t *testing.T) {
 			id4 := integration.NewIDAttribute("port", "1234")
 			pbEntity, err := testIntegration.Entity("testDB", "pgbouncer", id3, id4)
 			assert.Nil(t, err)
-			assert.Equal(t, testCase.expectedStats, pbEntity.Metrics[0].Metrics)
+			assert.Equal(t, expectedStats, pbEntity.Metrics[0].Metrics)
 			assert.Equal(t, testCase.expectedPool, pbEntity.Metrics[1].Metrics)
 		})
 	}

--- a/src/metrics/pgbouncer_definitions.go
+++ b/src/metrics/pgbouncer_definitions.go
@@ -38,17 +38,21 @@ var pgbouncerPoolsDefinition = &QueryDefinition{
 
 	dataModels: []struct {
 		databaseBase
-		User        *string `db:"user"`
-		ClCancelReq *int64  `db:"cl_cancel_req"  metric_name:"pgbouncer.pools.clientConnectionsCancelReq" source_type:"gauge"`
-		ClActive    *int64  `db:"cl_active"      metric_name:"pgbouncer.pools.clientConnectionsActive"    source_type:"gauge"`
-		ClWaiting   *int64  `db:"cl_waiting"     metric_name:"pgbouncer.pools.clientConnectionsWaiting"   source_type:"gauge"`
-		SvActive    *int64  `db:"sv_active"      metric_name:"pgbouncer.pools.serverConnectionsActive"    source_type:"gauge"`
-		SvIdle      *int64  `db:"sv_idle"        metric_name:"pgbouncer.pools.serverConnectionsIdle"      source_type:"gauge"`
-		SvUsed      *int64  `db:"sv_used"        metric_name:"pgbouncer.pools.serverConnectionsUsed"      source_type:"gauge"`
-		SvTested    *int64  `db:"sv_tested"      metric_name:"pgbouncer.pools.serverConnectionsTested"    source_type:"gauge"`
-		SvLogin     *int64  `db:"sv_login"       metric_name:"pgbouncer.pools.serverConnectionsLogin"     source_type:"gauge"`
-		MaxWait     *int64  `db:"maxwait"        metric_name:"pgbouncer.pools.maxwaitInMilliseconds"      source_type:"gauge"`
-		MaxWaitUs   *int64  `db:"maxwait_us"`
-		PoolMode    *string `db:"pool_mode"`
+		User               *string `db:"user"`
+		ClCancelReq        *int64  `db:"cl_cancel_req"         metric_name:"pgbouncer.pools.clientConnectionsCancelReq"        source_type:"gauge"` //removed in v1.18
+		ClActive           *int64  `db:"cl_active"             metric_name:"pgbouncer.pools.clientConnectionsActive"           source_type:"gauge"`
+		ClWaiting          *int64  `db:"cl_waiting"            metric_name:"pgbouncer.pools.clientConnectionsWaiting"          source_type:"gauge"`
+		ClWaitingCancelReq *int64  `db:"cl_waiting_cancel_req" metric_name:"pgbouncer.pools.clientConnectionsWaitingCancelReq" source_type:"gauge"` // added in v1.18
+		ClActiveCancelReq  *int64  `db:"cl_active_cancel_req"  metric_name:"pgbouncer.pools.clientConnectionsActiveCancelReq"  source_type:"gauge"` // added in v1.18
+		SvActiveCancel     *int64  `db:"sv_active_cancel"      metric_name:"pgbouncer.pools.serverConnectionsActiveCancel"     source_type:"gauge"` // added in v1.18
+		SvBeingCancel      *int64  `db:"sv_being_canceled"     metric_name:"pgbouncer.pools.serverConnectionsBeingCancel"      source_type:"gauge"` // added in v1.18
+		SvActive           *int64  `db:"sv_active"             metric_name:"pgbouncer.pools.serverConnectionsActive"           source_type:"gauge"`
+		SvIdle             *int64  `db:"sv_idle"               metric_name:"pgbouncer.pools.serverConnectionsIdle"             source_type:"gauge"`
+		SvUsed             *int64  `db:"sv_used"               metric_name:"pgbouncer.pools.serverConnectionsUsed"             source_type:"gauge"`
+		SvTested           *int64  `db:"sv_tested"             metric_name:"pgbouncer.pools.serverConnectionsTested"           source_type:"gauge"`
+		SvLogin            *int64  `db:"sv_login"              metric_name:"pgbouncer.pools.serverConnectionsLogin"            source_type:"gauge"`
+		MaxWait            *int64  `db:"maxwait"               metric_name:"pgbouncer.pools.maxwaitInMilliseconds"             source_type:"gauge"`
+		MaxWaitUs          *int64  `db:"maxwait_us"`
+		PoolMode           *string `db:"pool_mode"`
 	}{},
 }

--- a/src/metrics/pgbouncer_definitions.go
+++ b/src/metrics/pgbouncer_definitions.go
@@ -39,7 +39,7 @@ var pgbouncerPoolsDefinition = &QueryDefinition{
 	dataModels: []struct {
 		databaseBase
 		User               *string `db:"user"`
-		ClCancelReq        *int64  `db:"cl_cancel_req"         metric_name:"pgbouncer.pools.clientConnectionsCancelReq"        source_type:"gauge"` //removed in v1.18
+		ClCancelReq        *int64  `db:"cl_cancel_req"         metric_name:"pgbouncer.pools.clientConnectionsCancelReq"        source_type:"gauge"` // removed in v1.18
 		ClActive           *int64  `db:"cl_active"             metric_name:"pgbouncer.pools.clientConnectionsActive"           source_type:"gauge"`
 		ClWaiting          *int64  `db:"cl_waiting"            metric_name:"pgbouncer.pools.clientConnectionsWaiting"          source_type:"gauge"`
 		ClWaitingCancelReq *int64  `db:"cl_waiting_cancel_req" metric_name:"pgbouncer.pools.clientConnectionsWaitingCancelReq" source_type:"gauge"` // added in v1.18


### PR DESCRIPTION
Pgbouncer v1.18 [adds information](https://www.pgbouncer.org/changelog.html#pgbouncer-118x) about cancel request. Currently the integration will fail to retrieve the pools metrics for this version.

This PR adds this new metrics to the pgbouncer metric collection when the version is >17, for older versions metrics are not affected.:
`pgbouncer.pools.clientConnectionsWaitingCancelReq`
`pgbouncer.pools.clientConnectionsActiveCancelReq` 
`pgbouncer.pools.serverConnectionsActiveCancel`    
`pgbouncer.pools.serverConnectionsBeingCancel`

- [ ] add dirac issue
- [ ] add nr docs