### PR TITLE
chore(golang): ping golang version

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-buster
+FROM golang:1.20.6-bookworm
 
 ARG GH_VERSION='1.9.2'
 

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       POSTGRES_DB: demo
 
   nri-postgresql:
-    image: golang:1.20-buster
+    image: golang:1.20.6-bookworm
     container_name: nri_postgresql
     working_dir: /code
     depends_on:


### PR DESCRIPTION
We decided to pin golang version and [automerge them](https://github.com/newrelic/coreint-automation/commit/398ade41391d36da64320e123d832566d201601b)