### PR TITLE
Pipeline refactor

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -122,7 +122,8 @@ jobs:
       - name: Download zip from GH Release assets and extract .exe
         shell: pwsh
         run: |
-          build\windows\download_zip_extract_exe.ps1 "$env:INTEGRATION" ${{ matrix.goarch }} "$env:TAG" "$env:REPO_FULL_NAME"
+          build\windows\download_zip.ps1 "$env:INTEGRATION" ${{ matrix.goarch }} "$env:TAG" "$env:REPO_FULL_NAME"
+          build\windows\extract_exe.ps1 "$env:INTEGRATION" ${{ matrix.goarch }} "$env:TAG"
       - name: Create MSI
         shell: pwsh
         run: |

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -7,17 +7,18 @@ on:
       - master
       - renovate/**
   pull_request:
+  workflow_dispatch:
 
 env:
-  TAG: "v0.0.0" # needed for goreleaser windows builds
-  REPO_FULL_NAME: ${{ github.event.repository.full_name }}
+  INTEGRATION: "postgresql"
   ORIGINAL_REPO_NAME: "newrelic/nri-postgresql"
-  DOCKER_LOGIN_AVAILABLE: ${{ secrets.OHAI_DOCKER_HUB_ID }}
+  REPO_FULL_NAME: ${{ github.event.repository.full_name }}
+  TAG: "v0.0.0" # needed for fake-prereleases
 
 jobs:
   static-analysis:
     name: Run all static analysis checks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -41,7 +42,7 @@ jobs:
 
   test-nix:
     name: Run unit tests on *Nix
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Login to DockerHub
@@ -55,7 +56,7 @@ jobs:
 
   test-windows:
     name: Run unit tests on Windows
-    runs-on: windows-2022
+    runs-on: windows-latest
     env:
       GOPATH: ${{ github.workspace }}
     defaults:
@@ -72,12 +73,11 @@ jobs:
           go-version-file: "src/github.com/${{ env.ORIGINAL_REPO_NAME }}/go.mod"
       - name: Running unit tests
         shell: pwsh
-        run: |
-          .\build\windows\unit_tests.ps1
+        run: .\build\windows\unit_tests.ps1
 
   test-integration-nix:
     name: Run integration tests on *Nix
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: src/github.com/${{env.ORIGINAL_REPO_NAME}}
@@ -102,16 +102,68 @@ jobs:
           GOPATH: ${{ github.workspace }}
         run: make integration-test
 
-  test-build:
-    name: Test binary compilation for all platforms:arch
-    runs-on: ubuntu-22.04
+  test-build-nix:
+    name: Test binary compilation and packaging for linux
+    runs-on: ubuntu-latest
+    env:
+      GPG_MAIL: 'infrastructure-eng@newrelic.com'
+      GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
+      GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
     steps:
-      - uses: actions/checkout@v3
-      - name: Login to DockerHub
-        if: ${{env.DOCKER_LOGIN_AVAILABLE}}
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
-          password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
+      - uses: actions/checkout@v4
+      - run: |
+          git tag "$TAG"
+          if [ -z "$GPG_PASSPHRASE" ]; then
+            echo NO_SIGN=true >> $GITHUB_ENV
+          fi
       - name: Build all platforms:arch
-        run: make ci/build
+        run: make ci/fake-prerelease
+      - name: Upload artifacts for next job
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows-packages
+          path: dist/nri-*.zip
+
+  test-build-windows:
+    name: Create MSI
+    runs-on: windows-latest
+    needs: [test-build-nix]
+    env:
+      GOPATH: ${{ github.workspace }}
+      PFX_CERTIFICATE_BASE64: ${{ secrets.OHAI_PFX_CERTIFICATE_BASE64 }} # base64 encoded
+      PFX_CERTIFICATE_DESCRIPTION: 'New Relic'
+      PFX_PASSPHRASE:  ${{ secrets.OHAI_PFX_PASSPHRASE }}
+    defaults:
+      run:
+        working-directory: src/github.com/${{ env.ORIGINAL_REPO_NAME }}
+    strategy:
+      matrix:
+        goarch: [amd64,386]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: src/github.com/${{ env.ORIGINAL_REPO_NAME }}
+      - shell: bash
+        run: git tag "$TAG"
+
+      - name: Download artifact from previous job
+        uses: actions/download-artifact@v3
+        with:
+          name: windows-packages
+          path: src/github.com/${{ env.ORIGINAL_REPO_NAME }}/dist/
+
+      - name: Get PFX certificate from GH secrets
+        shell: bash
+        run: |
+          if [ -z "$PFX_CERTIFICATE_BASE64" ]; then
+            echo NO_SIGN=true >> $GITHUB_ENV
+          else
+            printf "%s" "$PFX_CERTIFICATE_BASE64" | base64 -d - > wincert.pfx
+          fi
+      - name: Extract .exe
+        shell: pwsh
+        run: build\windows\extract_exe.ps1 "$env:INTEGRATION" ${{ matrix.goarch }} "$env:TAG"
+      - name: Create MSI
+        shell: pwsh
+        run: build\windows\package_msi.ps1 -integration "$env:INTEGRATION" -arch ${{ matrix.goarch }} -tag "$env:TAG" -pfx_passphrase "$env:PFX_PASSPHRASE" -pfx_certificate_description "$env:PFX_CERTIFICATE_DESCRIPTION"

--- a/build/ci.mk
+++ b/build/ci.mk
@@ -72,3 +72,26 @@ else
 	@echo "===> $(INTEGRATION) ===  [ci/prerelease] TAG env variable expected to be set"
 	exit 1
 endif
+
+.PHONY : ci/fake-prerelease
+ci/fake-prerelease: ci/deps
+ifdef TAG
+	@docker run --rm -t \
+			--name "nri-$(INTEGRATION)-prerelease" \
+			-v $(CURDIR):/go/src/github.com/newrelic/nri-$(INTEGRATION) \
+			-w /go/src/github.com/newrelic/nri-$(INTEGRATION) \
+			-e INTEGRATION \
+			-e PRERELEASE=true \
+			-e NO_PUBLISH=true \
+			-e NO_SIGN \
+			-e GITHUB_TOKEN \
+			-e REPO_FULL_NAME \
+			-e TAG \
+			-e GPG_MAIL \
+			-e GPG_PASSPHRASE \
+			-e GPG_PRIVATE_KEY_BASE64 \
+			$(BUILDER_TAG) make release
+else
+	@echo "===> $(INTEGRATION) ===  [ci/fake-prerelease] TAG env variable expected to be set"
+	exit 1
+endif

--- a/build/package/windows/nri-386-installer/nri-installer.wixproj
+++ b/build/package/windows/nri-386-installer/nri-installer.wixproj
@@ -8,7 +8,7 @@
         <SchemaVersion>2.0</SchemaVersion>
         <OutputName>nri-$(IntegrationName)-386</OutputName>
         <OutputType>Package</OutputType>
-        <SignToolPath>C:\Program Files (x86)\Windows Kits\10\bin\x64\</SignToolPath>
+        <SignToolPath>C:\Program Files (x86)\Microsoft SDKs\ClickOnce\SignTool\</SignToolPath>
         <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
         <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
         <Name>newrelic-nri-$(IntegrationName)-installer</Name>

--- a/build/package/windows/nri-386-installer/nri-installer.wixproj
+++ b/build/package/windows/nri-386-installer/nri-installer.wixproj
@@ -44,7 +44,7 @@
         </CreateProperty>
     </Target>
     <Target Name="SignInstaller">
-        <Exec Command="&quot;$(SignToolPath)signtool.exe&quot; sign /s &quot;My&quot; /d &quot;$(pfx_certificate_description)&quot; /n &quot;$(pfx_certificate_description)&quot; &quot;$(OutputPath)$(OutputName).msi&quot;"/>
+        <Exec Condition="'$(noSign)' != 'true'" Command="&quot;$(SignToolPath)signtool.exe&quot; sign /s &quot;My&quot; /d &quot;$(pfx_certificate_description)&quot; /n &quot;$(pfx_certificate_description)&quot; &quot;$(OutputPath)$(OutputName).msi&quot;"/>
         <Copy SourceFiles="$(OutputPath)$(OutputName).msi" DestinationFiles="$(OutputPath)$(OutputName).x.y.z.msi"/>
         <!-- <Delete Files="$(OutputPath)$(OutputName).msi" /> -->
     </Target>

--- a/build/package/windows/nri-amd64-installer/nri-installer.wixproj
+++ b/build/package/windows/nri-amd64-installer/nri-installer.wixproj
@@ -8,7 +8,7 @@
         <SchemaVersion>2.0</SchemaVersion>
         <OutputName>nri-$(IntegrationName)-amd64</OutputName>
         <OutputType>Package</OutputType>
-        <SignToolPath>C:\Program Files (x86)\Windows Kits\10\bin\x64\</SignToolPath>
+        <SignToolPath>C:\Program Files (x86)\Microsoft SDKs\ClickOnce\SignTool\</SignToolPath>
         <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
         <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
         <Name>newrelic-nri-$(IntegrationName)-installer</Name>

--- a/build/package/windows/nri-amd64-installer/nri-installer.wixproj
+++ b/build/package/windows/nri-amd64-installer/nri-installer.wixproj
@@ -44,7 +44,7 @@
         </CreateProperty>
     </Target>
     <Target Name="SignInstaller">
-        <Exec Command="&quot;$(SignToolPath)signtool.exe&quot; sign /s &quot;My&quot; /d &quot;$(pfx_certificate_description)&quot; /n &quot;$(pfx_certificate_description)&quot; &quot;$(OutputPath)$(OutputName).msi&quot;"/>
+        <Exec Condition="'$(noSign)' != 'true'" Command="&quot;$(SignToolPath)signtool.exe&quot; sign /s &quot;My&quot; /d &quot;$(pfx_certificate_description)&quot; /n &quot;$(pfx_certificate_description)&quot; &quot;$(OutputPath)$(OutputName).msi&quot;"/>
         <Copy SourceFiles="$(OutputPath)$(OutputName).msi" DestinationFiles="$(OutputPath)$(OutputName).x.y.z.msi"/>
         <!-- <Delete Files="$(OutputPath)$(OutputName).msi" /> -->
     </Target>

--- a/build/release.mk
+++ b/build/release.mk
@@ -42,14 +42,21 @@ release/fix-archive:
 
 .PHONY : release/sign/nix
 release/sign/nix:
+ifneq ($(NO_SIGN), true)
 	@echo "===> $(INTEGRATION) === [release/sign] signing packages"
 	@bash $(CURDIR)/build/nix/sign.sh
-
+else
+	@echo "===> $(INTEGRATION) === [release/sign] signing packages is disabled by environment variable"
+endif
 
 .PHONY : release/publish
 release/publish:
+ifneq ($(NO_PUBLISH), true)
 	@echo "===> $(INTEGRATION) === [release/publish] publishing artifacts"
 	@bash $(CURDIR)/build/upload_artifacts_gh.sh
+else
+	@echo "===> $(INTEGRATION) === [release/publish] publish is disabled by environment variable"
+endif
 
 .PHONY : release
 release: release/build release/fix-archive release/sign/nix release/publish release/clean

--- a/build/windows/download_zip.ps1
+++ b/build/windows/download_zip.ps1
@@ -5,15 +5,12 @@ param (
     [string]$REPO_FULL_NAME="none"
 )
 write-host "===> Creating dist folder"
-New-Item -ItemType directory -Path .\dist
+New-Item -ItemType directory -Path .\dist -Force
 
 $VERSION=${TAG}.substring(1)
-$exe_folder="nri-${INTEGRATION}_windows_${ARCH}"
 $zip_name="nri-${INTEGRATION}-${ARCH}.${VERSION}.zip"
 
 $zip_url="https://github.com/${REPO_FULL_NAME}/releases/download/${TAG}/${zip_name}"
 write-host "===> Downloading & extracting .exe from ${zip_url}"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 Invoke-WebRequest "${zip_url}" -OutFile ".\dist\${zip_name}"
-write-host "===> Expanding"
-expand-archive -path "dist\${zip_name}" -destinationpath "dist\${exe_folder}\"

--- a/build/windows/extract_exe.ps1
+++ b/build/windows/extract_exe.ps1
@@ -1,0 +1,14 @@
+param (
+    [string]$INTEGRATION="none",
+    [string]$ARCH="amd64",
+    [string]$TAG="v0.0.0"
+)
+write-host "===> Creating dist folder"
+New-Item -ItemType directory -Path .\dist -Force
+
+$VERSION=${TAG}.substring(1)
+$exe_folder="nri-${INTEGRATION}_windows_${ARCH}"
+$zip_name="nri-${INTEGRATION}-${ARCH}.${VERSION}.zip"
+
+write-host "===> Expanding"
+expand-archive -path "dist\${zip_name}" -destinationpath "dist\${exe_folder}\"


### PR DESCRIPTION
We are not testing packaging at PR time. This PR add `fake-prerelease` that does exactly the same as prerelease without uploading the artifacts to GitHub.