### PR TITLE
feat: add option to filter by table names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### enhancement
+- Added `COLLECTION_IGNORE_TABLE_LIST` in order to filter by table name.
+
 ## v2.13.7 - 2024-08-12
 
 ### ⛓️ Dependencies

--- a/postgresql-config.yml.k8s_sample
+++ b/postgresql-config.yml.k8s_sample
@@ -46,6 +46,11 @@
             # COLLECTION_IGNORE_DATABASE_LIST: '["azure_maintenance","azure_sys"]'
             #
             # COLLECTION_IGNORE_DATABASE_LIST: '[]'
+
+            # JSON array of table names that will be ignored for metrics collection.
+            # Defaults to empty '[]'.
+            # Example:
+            # COLLECTION_IGNORE_TABLE_LIST: '["table1","table2"]'
             
             # True if database lock metrics should be collected
             # Note: requires that the `tablefunc` extension be installed on the public schema

--- a/postgresql-config.yml.sample
+++ b/postgresql-config.yml.sample
@@ -34,6 +34,12 @@ integrations:
     # Example:
     # COLLECTION_IGNORE_DATABASE_LIST: '["azure_maintenance","azure_sys"]'
 
+    # JSON array of table names that will be ignored for metrics collection.
+    # Typically useful for cases where COLLECTION_LIST is set to 'ALL' and some databases need to be ignored.
+    # Defaults to empty '[]'.
+    # Example:
+    # COLLECTION_IGNORE_TABLE_LIST: '["table1","table2"]'
+
     # True if database lock metrics should be collected
     # Note: requires that the `tablefunc` extension be installed on the public schema
     # of the database where lock metrics will be collected.

--- a/postgresql-config.yml.sample
+++ b/postgresql-config.yml.sample
@@ -35,7 +35,6 @@ integrations:
     # COLLECTION_IGNORE_DATABASE_LIST: '["azure_maintenance","azure_sys"]'
 
     # JSON array of table names that will be ignored for metrics collection.
-    # Typically useful for cases where COLLECTION_LIST is set to 'ALL' and some databases need to be ignored.
     # Defaults to empty '[]'.
     # Example:
     # COLLECTION_IGNORE_TABLE_LIST: '["table1","table2"]'

--- a/src/args/argument_list.go
+++ b/src/args/argument_list.go
@@ -18,6 +18,7 @@ type ArgumentList struct {
 	Port                         string `default:"5432" help:"The port to connect to the PostgreSQL database"`
 	CollectionList               string `default:"{}" help:"A JSON object which defines the databases, schemas, tables, and indexes to collect. Can also be a JSON array that list databases to be collected. Can also be the string literal 'ALL' to collect everything. Collects nothing by default."`
 	CollectionIgnoreDatabaseList string `default:"[]" help:"A JSON array that list databases that will be excluded from collection. Nothing is excluded by default."`
+	CollectionIgnoreTableList    string `default:"[]" help:"A JSON array that list tables that will be excluded from collection. Nothing is excluded by default."`
 	SSLRootCertLocation          string `default:"" help:"Absolute path to PEM encoded root certificate file"`
 	SSLCertLocation              string `default:"" help:"Absolute path to PEM encoded client cert file"`
 	SSLKeyLocation               string `default:"" help:"Absolute path to PEM encoded client key file"`

--- a/src/collection/collection_test.go
+++ b/src/collection/collection_test.go
@@ -20,7 +20,8 @@ func Test_buildSchemaListForDatabase(t *testing.T) {
 	mock.ExpectQuery(dbSchemaQuery).WillReturnRows(instanceRows)
 	mock.ExpectClose()
 
-	schemaList, err := buildSchemaListForDatabase(testConnection)
+	ignoreTableList := tableIgnoreList{}
+	schemaList, err := buildSchemaListForDatabase(testConnection, ignoreTableList)
 	assert.Nil(t, err)
 	testConnection.Close()
 
@@ -45,7 +46,8 @@ func Test_buildSchemaListForDatabase_TableOnly(t *testing.T) {
 	mock.ExpectQuery(dbSchemaQuery).WillReturnRows(instanceRows)
 	mock.ExpectClose()
 
-	schemaList, err := buildSchemaListForDatabase(testConnection)
+	ignoreTableList := tableIgnoreList{}
+	schemaList, err := buildSchemaListForDatabase(testConnection, ignoreTableList)
 	assert.Nil(t, err)
 
 	testConnection.Close()
@@ -67,6 +69,7 @@ func TestBuildCollectionList_DatabaseList(t *testing.T) {
 	al := args.ArgumentList{
 		CollectionList:               `["database1", "database2", "ignored_database"]`,
 		CollectionIgnoreDatabaseList: `["ignored_database"]`,
+		CollectionIgnoreTableList:    `["ignored_table"]`,
 	}
 
 	ci := connection.MockInfo{}
@@ -119,6 +122,7 @@ func TestBuildCollectionList_DetailedList(t *testing.T) {
                           "ignored_database": {"schema1": { "table1": ["index1"] }}
                          }`,
 		CollectionIgnoreDatabaseList: `["ignored_database"]`,
+		CollectionIgnoreTableList:    `["ignored_table"]`,
 	}
 
 	expected := DatabaseList{
@@ -138,6 +142,7 @@ func TestBuildCollectionList_All(t *testing.T) {
 	al := args.ArgumentList{
 		CollectionList:               `all`,
 		CollectionIgnoreDatabaseList: `["ignored_database"]`,
+		CollectionIgnoreTableList:    `["ignored_table"]`,
 	}
 
 	ci := connection.MockInfo{}

--- a/src/collection/collection_test.go
+++ b/src/collection/collection_test.go
@@ -20,7 +20,7 @@ func Test_buildSchemaListForDatabase(t *testing.T) {
 	mock.ExpectQuery(dbSchemaQuery).WillReturnRows(instanceRows)
 	mock.ExpectClose()
 
-	ignoreTableList := tableIgnoreList{}
+	ignoreTableList := ignoreList{}
 	schemaList, err := buildSchemaListForDatabase(testConnection, ignoreTableList)
 	assert.Nil(t, err)
 	testConnection.Close()
@@ -46,7 +46,7 @@ func Test_buildSchemaListForDatabase_TableOnly(t *testing.T) {
 	mock.ExpectQuery(dbSchemaQuery).WillReturnRows(instanceRows)
 	mock.ExpectClose()
 
-	ignoreTableList := tableIgnoreList{}
+	ignoreTableList := ignoreList{}
 	schemaList, err := buildSchemaListForDatabase(testConnection, ignoreTableList)
 	assert.Nil(t, err)
 


### PR DESCRIPTION
Added `COLLECTION_IGNORE_TABLE_LIST` as an option in the config file. Works in a similar way as `COLLECTION_IGNORE_DATABASE_LIST`. 

I have probably overlooked other things that need to be modified, and some adjustments may be needed to get it working at 100%. However, I tested it locally with a PostgreSQL v15.7 and the filter works as expected. 