### PR TITLE
[NR-313485] fix: include missing schema name on queries

### DIFF
--- a/src/metrics/index_definitions.go
+++ b/src/metrics/index_definitions.go
@@ -23,14 +23,15 @@ var indexDefinition = &QueryDefinition{
 					idx_tup_read AS tuples_read,
 					idx_tup_fetch AS tuples_fetched
 			FROM pg_tables t
-			LEFT OUTER JOIN pg_class c ON t.tablename=c.relname
 			LEFT OUTER JOIN
-					( SELECT c.relname AS ctablename, x.indexrelid indexoid, ipg.relname AS indexname, x.indnatts AS number_of_columns, idx_scan, idx_tup_read, idx_tup_fetch, indexrelname, indisunique FROM pg_index x
+					( SELECT c.relname AS ctablename, n.nspname AS cschemaname, x.indexrelid indexoid, ipg.relname AS indexname, x.indnatts AS number_of_columns, idx_scan, idx_tup_read, idx_tup_fetch, indexrelname, indisunique FROM pg_index x
 								 JOIN pg_class c ON c.oid = x.indrelid
+								 JOIN pg_namespace n ON c.relnamespace = n.oid
 								 JOIN pg_class ipg ON ipg.oid = x.indexrelid
-								 JOIN pg_stat_all_indexes psai ON x.indexrelid = psai.indexrelid )
+								 JOIN pg_stat_all_indexes psai ON x.indexrelid = psai.indexrelid
+					)
 					AS foo
-					ON t.tablename = foo.ctablename
+					ON t.tablename = foo.ctablename AND t.schemaname = foo.cschemaname
 			where indexname is not null and t.schemaname || '.' || t.tablename || '.' || indexname in (%SCHEMA_TABLE_INDEXES%)
 			ORDER BY 1,2;`,
 

--- a/src/metrics/table_definitions.go
+++ b/src/metrics/table_definitions.go
@@ -53,11 +53,13 @@ var tableDefinition = &QueryDefinition{
 			n_live_tup, -- table.liveRows
 			n_dead_tup -- table.deadRows
 		FROM pg_statio_user_tables as statio
-		join pg_stat_user_tables as stat
-		on stat.relid=statio.relid
-		join pg_class c
-		on c.relname=stat.relname
-		where stat.schemaname::text || '.' || stat.relname::text in (%SCHEMA_TABLES%)`,
+		JOIN pg_stat_user_tables as stat
+			ON stat.relid=statio.relid
+		JOIN pg_class c
+			ON c.relname=stat.relname
+		JOIN pg_namespace n
+    		ON c.relnamespace = n.oid
+		WHERE n.nspname = stat.schemaname AND stat.schemaname::text || '.' || stat.relname::text in (%SCHEMA_TABLES%)`,
 
 	dataModels: []struct {
 		databaseBase


### PR DESCRIPTION
This PR updates two query definitions to take the table's schema into account.

The schema is taken from [pg_namespace](https://www.postgresql.org/docs/current/catalog-pg-namespace.html) which needs to be joined to [pg_class](https://www.postgresql.org/docs/current/catalog-pg-class.html). An alternative approach would be casting the `pg_class.relnamespace` value to the human-readable namespace using `::regnamespace`. But `regnamespace` wasn't introduced until [PostgreSQL 9.5](https://www.postgresql.org/docs/release/9.5.0/) and it wouldn't work on previous versions.