### PR TITLE
Nr 280084 add support for postgre sql v17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
-### 🚀 Enhancements
+### Enhancements
 - Added support for PostgreSQL v17 
 
-### ⚠️ Breaking Changes
+### Breaking Changes
 - Metric collection updated to reflect PostgreSQL v17 table structure changes:
   - Metrics previously collected from `pg_stat_bgwriter` are now collected from:
     - `pg_stat_checkpointer`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
-### Enhancements
+## v2.16.0 - 2024-11-06
+
+### 🚀 Enhancements
 - Added support for pgbouncer v1.23 with new columns in `STATS` table.
+- Added support for PostgreSQL v17
+- Metrics are updated to reflect PostgreSQL v17 metrics origin (metrics collected from `pg_stat_bgwriter` are now collected from `pg_stat_checkpointer` and `pg_stat_io`) when PostgreSQL v17 is used. Specifically: `bgwriter.buffersWrittenForCheckpointsPerSecond` → `checkpointer.buffersWrittenForCheckpointsPerSecond`, `bgwriter.checkpointSyncTimeInMillisecondsPerSecond` → `checkpointer.checkpointSyncTimeInMillisecondsPerSecond`, `bgwriter.checkpointWriteTimeInMillisecondsPerSecond` → `checkpointer.checkpointWriteTimeInMillisecondsPerSecond`, `bgwriter.checkpointsRequestedPerSecond` → `checkpointer.checkpointsRequestedPerSecond`, `bgwriter.checkpointsScheduledPerSecond` → `checkpointer.checkpointsScheduledPerSecond`, `bgwriter.backendFsyncCallsPerSecond` → `io.backendFsyncCallsPerSecond`, `bgwriter.buffersWrittenByBackendPerSecond` → `io.buffersWrittenByBackendPerSecond`.
 
 ## v2.15.0 - 2024-10-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### 🚀 Enhancements
+- Added support for PostgreSQL v17 
+
+### ⚠️ Breaking Changes
+- Metric collection updated to reflect PostgreSQL v17 table structure changes:
+  - Metrics previously collected from `pg_stat_bgwriter` are now collected from:
+    - `pg_stat_checkpointer`
+    - `pg_stat_io`
+  - Variable names have changed from original `pg_stat_bgwriter` metrics to reflect new table structure:
+    - `bgwriter.buffersWrittenForCheckpointsPerSecond` → `checkpointer.buffersWrittenForCheckpointsPerSecond`
+    - `bgwriter.checkpointSyncTimeInMillisecondsPerSecond` → `checkpointer.checkpointSyncTimeInMillisecondsPerSecond`
+    - `bgwriter.checkpointWriteTimeInMillisecondsPerSecond` → `checkpointer.checkpointWriteTimeInMillisecondsPerSecond`
+    - `bgwriter.checkpointsRequestedPerSecond` → `checkpointer.checkpointsRequestedPerSecond`
+    - `bgwriter.checkpointsScheduledPerSecond` → `checkpointer.checkpointsScheduledPerSecond`
+    - `bgwriter.backendFsyncCallsPerSecond` → `io.backendFsyncCallsPerSecond`
+    - `bgwriter.buffersWrittenByBackendPerSecond` → `io.buffersWrittenByBackendPerSecond`
+
 ## v2.15.0 - 2024-10-07
 
 ### dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,7 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
-## v2.16.0 - 2024-11-06
-
-### 🚀 Enhancements
+### enhancements
 - Added support for pgbouncer v1.23 with new columns in `STATS` table.
 - Added support for PostgreSQL v17
 - Metrics are updated to reflect PostgreSQL v17 metrics origin (metrics collected from `pg_stat_bgwriter` are now collected from `pg_stat_checkpointer` and `pg_stat_io`) when PostgreSQL v17 is used. Specifically: `bgwriter.buffersWrittenForCheckpointsPerSecond` → `checkpointer.buffersWrittenForCheckpointsPerSecond`, `bgwriter.checkpointSyncTimeInMillisecondsPerSecond` → `checkpointer.checkpointSyncTimeInMillisecondsPerSecond`, `bgwriter.checkpointWriteTimeInMillisecondsPerSecond` → `checkpointer.checkpointWriteTimeInMillisecondsPerSecond`, `bgwriter.checkpointsRequestedPerSecond` → `checkpointer.checkpointsRequestedPerSecond`, `bgwriter.checkpointsScheduledPerSecond` → `checkpointer.checkpointsScheduledPerSecond`, `bgwriter.backendFsyncCallsPerSecond` → `io.backendFsyncCallsPerSecond`, `bgwriter.buffersWrittenByBackendPerSecond` → `io.buffersWrittenByBackendPerSecond`.

--- a/src/metrics/instance_definitions.go
+++ b/src/metrics/instance_definitions.go
@@ -5,23 +5,25 @@ import (
 )
 
 func generateInstanceDefinitions(version *semver.Version) []*QueryDefinition {
-	queryDefinitions := make([]*QueryDefinition, 1, 5)
+	queryDefinitions := make([]*QueryDefinition, 1, 3)
 	v91 := semver.MustParse("9.1.0")
 	v92 := semver.MustParse("9.2.0")
 	v170 := semver.MustParse("17.0.0")
 
-	queryDefinitions[0] = instanceDefinitionBase
+	if !version.GE(v170) {
+		queryDefinitions[0] = instanceDefinitionBase
 
-	if version.GE(v91) {
-		queryDefinitions = append(queryDefinitions, instanceDefinition91)
-	}
+		if version.GE(v91) {
+			queryDefinitions = append(queryDefinitions, instanceDefinition91)
+		}
 
-	if version.GE(v92) {
-		queryDefinitions = append(queryDefinitions, instanceDefinition92)
-	}
+		if version.GE(v92) {
+			queryDefinitions = append(queryDefinitions, instanceDefinition92)
+		}
 
-	if version.GE(v170) {
-		queryDefinitions = append(queryDefinitions, instanceDefinitionBase170, instanceDefinition170)
+	} else {
+		queryDefinitions[0] = instanceDefinitionBase170
+		queryDefinitions = append(queryDefinitions, instanceDefinition170)
 	}
 
 	return queryDefinitions

--- a/src/metrics/instance_definitions.go
+++ b/src/metrics/instance_definitions.go
@@ -4,29 +4,52 @@ import (
 	"github.com/blang/semver/v4"
 )
 
+type VersionDefinition struct {
+	minVersion       semver.Version
+	queryDefinitions []*QueryDefinition
+}
+
+var versionDefinitions = []VersionDefinition{
+	{
+		minVersion: semver.MustParse("17.0.0"),
+		queryDefinitions: []*QueryDefinition{
+			instanceDefinitionBase170,
+			instanceDefinition170,
+		},
+	},
+	{
+		minVersion: semver.MustParse("9.2.0"),
+		queryDefinitions: []*QueryDefinition{
+			instanceDefinitionBase,
+			instanceDefinition91,
+			instanceDefinition92,
+		},
+	},
+	{
+		minVersion: semver.MustParse("9.1.0"),
+		queryDefinitions: []*QueryDefinition{
+			instanceDefinitionBase,
+			instanceDefinition91,
+		},
+	},
+	{
+		minVersion: semver.MustParse("0.0.0"),
+		queryDefinitions: []*QueryDefinition{
+			instanceDefinitionBase,
+		},
+	},
+}
+
 func generateInstanceDefinitions(version *semver.Version) []*QueryDefinition {
-	queryDefinitions := make([]*QueryDefinition, 1, 3)
-	v91 := semver.MustParse("9.1.0")
-	v92 := semver.MustParse("9.2.0")
-	v170 := semver.MustParse("17.0.0")
-
-	if !version.GE(v170) {
-		queryDefinitions[0] = instanceDefinitionBase
-
-		if version.GE(v91) {
-			queryDefinitions = append(queryDefinitions, instanceDefinition91)
+	// Find the first version definition that's applicable
+	for _, versionDef := range versionDefinitions {
+		if version.GE(versionDef.minVersion) {
+			return versionDef.queryDefinitions
 		}
-
-		if version.GE(v92) {
-			queryDefinitions = append(queryDefinitions, instanceDefinition92)
-		}
-
-	} else {
-		queryDefinitions[0] = instanceDefinitionBase170
-		queryDefinitions = append(queryDefinitions, instanceDefinition170)
 	}
 
-	return queryDefinitions
+	// This should never happen due to the "0.0.0" fallback version,
+	return []*QueryDefinition{instanceDefinitionBase}
 }
 
 var instanceDefinitionBase = &QueryDefinition{

--- a/src/metrics/instance_definitions.go
+++ b/src/metrics/instance_definitions.go
@@ -5,9 +5,10 @@ import (
 )
 
 func generateInstanceDefinitions(version *semver.Version) []*QueryDefinition {
-	queryDefinitions := make([]*QueryDefinition, 1, 3)
+	queryDefinitions := make([]*QueryDefinition, 1, 5)
 	v91 := semver.MustParse("9.1.0")
 	v92 := semver.MustParse("9.2.0")
+	v170 := semver.MustParse("17.0.0")
 
 	queryDefinitions[0] = instanceDefinitionBase
 
@@ -17,6 +18,10 @@ func generateInstanceDefinitions(version *semver.Version) []*QueryDefinition {
 
 	if version.GE(v92) {
 		queryDefinitions = append(queryDefinitions, instanceDefinition92)
+	}
+
+	if version.GE(v170) {
+		queryDefinitions = append(queryDefinitions, instanceDefinitionBase170, instanceDefinition170)
 	}
 
 	return queryDefinitions
@@ -62,6 +67,38 @@ var instanceDefinition92 = &QueryDefinition{
 
 	dataModels: []struct {
 		CheckpointWriteTime *int64 `db:"time_writing_checkpoint_files_to_disk"       metric_name:"bgwriter.checkpointWriteTimeInMillisecondsPerSecond" source_type:"rate"`
-		CheckpointSynTime   *int64 `db:"time_synchronizing_checkpoint_files_to_disk" metric_name:"bgwriter.checkpointSyncTimeInMillisecondsPerSecond"  source_type:"rate"`
+		CheckpointSyncTime  *int64 `db:"time_synchronizing_checkpoint_files_to_disk" metric_name:"bgwriter.checkpointSyncTimeInMillisecondsPerSecond"  source_type:"rate"`
+	}{},
+}
+
+var instanceDefinitionBase170 = &QueryDefinition{
+	query: `SELECT
+		BG.buffers_clean AS buffers_written_by_background_writer,
+		BG.maxwritten_clean AS background_writer_stops,
+		BG.buffers_alloc AS buffers_allocated
+		FROM pg_stat_bgwriter BG;`,
+
+	dataModels: []struct {
+		BuffersWrittenByBackgroundWriter *int64 `db:"buffers_written_by_background_writer" metric_name:"bgwriter.buffersWrittenByBackgroundWriterPerSecond" source_type:"rate"`
+		BackgroundWriterStops            *int64 `db:"background_writer_stops"              metric_name:"bgwriter.backgroundWriterStopsPerSecond"            source_type:"rate"`
+		BuffersAllocated                 *int64 `db:"buffers_allocated"                    metric_name:"bgwriter.buffersAllocatedPerSecond"                 source_type:"rate"`
+	}{},
+}
+
+var instanceDefinition170 = &QueryDefinition{
+	query: `SELECT 
+		BG.num_timed AS scheduled_checkpoints_performed,
+		BG.num_requested AS requested_checkpoints_performed,
+		BG.buffers_written AS buffers_written_during_checkpoint,
+		cast(BG.write_time AS bigint) AS time_writing_checkpoint_files_to_disk,
+		cast(BG.sync_time AS bigint) AS time_synchronizing_checkpoint_files_to_disk
+		FROM pg_stat_checkpointer BG;`,
+
+	dataModels: []struct {
+		ScheduledCheckpointsPerformed  *int64 `db:"scheduled_checkpoints_performed"             metric_name:"checkpointer.checkpointsScheduledPerSecond"                  source_type:"rate"`
+		RequestedCheckpointsPerformed  *int64 `db:"requested_checkpoints_performed"             metric_name:"checkpointer.checkpointsRequestedPerSecond"              source_type:"rate"`
+		BuffersWrittenDuringCheckpoint *int64 `db:"buffers_written_during_checkpoint"           metric_name:"checkpointer.buffersWrittenForCheckpointsPerSecond"      source_type:"rate"`
+		CheckpointWriteTime            *int64 `db:"time_writing_checkpoint_files_to_disk"       metric_name:"checkpointer.checkpointWriteTimeInMillisecondsPerSecond" source_type:"rate"`
+		CheckpointSyncTime             *int64 `db:"time_synchronizing_checkpoint_files_to_disk" metric_name:"checkpointer.checkpointSyncTimeInMillisecondsPerSecond"  source_type:"rate"`
 	}{},
 }

--- a/src/metrics/instance_definitions_test.go
+++ b/src/metrics/instance_definitions_test.go
@@ -9,44 +9,52 @@ import (
 
 func Test_generateInstanceDefinitions(t *testing.T) {
 	tests := []struct {
-		name           string
-		version        string
-		expectedLength int
+		name            string
+		version         string
+		expectedQueries []*QueryDefinition
+		errorExpected   bool
 	}{
 		{
-			name:           "PostgreSQL 9.0",
-			version:        "9.0.0",
-			expectedLength: 1,
+			name:            "PostgreSQL 9.0",
+			version:         "9.0.0",
+			expectedQueries: []*QueryDefinition{instanceDefinitionBase},
+			errorExpected:   false,
 		},
 		{
-			name:           "PostgreSQL 9.1",
-			version:        "9.1.0",
-			expectedLength: 2,
+			name:            "PostgreSQL 9.1",
+			version:         "9.1.0",
+			expectedQueries: []*QueryDefinition{instanceDefinitionBase, instanceDefinition91},
+			errorExpected:   false,
 		},
 		{
-			name:           "PostgreSQL 9.2",
-			version:        "9.2.0",
-			expectedLength: 3,
+			name:            "PostgreSQL 9.2",
+			version:         "9.2.0",
+			expectedQueries: []*QueryDefinition{instanceDefinitionBase, instanceDefinition91, instanceDefinition92},
+			errorExpected:   false,
 		},
 		{
-			name:           "PostgreSQL 10.2",
-			version:        "10.2.0",
-			expectedLength: 3,
+			name:            "PostgreSQL 10.2",
+			version:         "10.2.0",
+			expectedQueries: []*QueryDefinition{instanceDefinitionBase, instanceDefinition91, instanceDefinition92},
+			errorExpected:   false,
 		},
 		{
-			name:           "PostgreSQL 16.4",
-			version:        "16.4.2",
-			expectedLength: 3,
+			name:            "PostgreSQL 16.4",
+			version:         "16.4.2",
+			expectedQueries: []*QueryDefinition{instanceDefinitionBase, instanceDefinition91, instanceDefinition92},
+			errorExpected:   false,
 		},
 		{
-			name:           "PostgreSQL 17.0",
-			version:        "17.0.0",
-			expectedLength: 3,
+			name:            "PostgreSQL 17.0",
+			version:         "17.0.0",
+			expectedQueries: []*QueryDefinition{instanceDefinitionBase170, instanceDefinition170, instanceDefinitionInputOutput170},
+			errorExpected:   false,
 		},
 		{
-			name:           "PostgreSQL 17.5",
-			version:        "17.5.0",
-			expectedLength: 3,
+			name:            "PostgreSQL 17.5 out of order",
+			version:         "17.5.0",
+			expectedQueries: []*QueryDefinition{instanceDefinition170, instanceDefinitionInputOutput170, instanceDefinitionBase170},
+			errorExpected:   true,
 		},
 	}
 
@@ -54,7 +62,13 @@ func Test_generateInstanceDefinitions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			version := semver.MustParse(tt.version)
 			queryDefinitions := generateInstanceDefinitions(&version)
-			assert.Equal(t, tt.expectedLength, len(queryDefinitions))
+			assert.Equal(t, len(tt.expectedQueries), len(queryDefinitions))
+
+			if tt.errorExpected {
+				assert.False(t, assert.ObjectsAreEqual(tt.expectedQueries, queryDefinitions))
+			} else {
+				assert.ElementsMatch(t, tt.expectedQueries, queryDefinitions)
+			}
 		})
 	}
 }

--- a/src/metrics/instance_definitions_test.go
+++ b/src/metrics/instance_definitions_test.go
@@ -7,44 +7,54 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_generateInstanceDefinitions90(t *testing.T) {
-	v := semver.MustParse("9.0.0")
-	queryDefinitions := generateInstanceDefinitions(&v)
+func Test_generateInstanceDefinitions(t *testing.T) {
+	tests := []struct {
+		name           string
+		version        string
+		expectedLength int
+	}{
+		{
+			name:           "PostgreSQL 9.0",
+			version:        "9.0.0",
+			expectedLength: 1,
+		},
+		{
+			name:           "PostgreSQL 9.1",
+			version:        "9.1.0",
+			expectedLength: 2,
+		},
+		{
+			name:           "PostgreSQL 9.2",
+			version:        "9.2.0",
+			expectedLength: 3,
+		},
+		{
+			name:           "PostgreSQL 10.2",
+			version:        "10.2.0",
+			expectedLength: 3,
+		},
+		{
+			name:           "PostgreSQL 16.4",
+			version:        "16.4.2",
+			expectedLength: 3,
+		},
+		{
+			name:           "PostgreSQL 17.0",
+			version:        "17.0.0",
+			expectedLength: 3,
+		},
+		{
+			name:           "PostgreSQL 17.5",
+			version:        "17.5.0",
+			expectedLength: 3,
+		},
+	}
 
-	assert.Equal(t, 1, len(queryDefinitions))
-}
-
-func Test_generateInstanceDefinitions91(t *testing.T) {
-	v := semver.MustParse("9.1.0")
-	queryDefinitions := generateInstanceDefinitions(&v)
-
-	assert.Equal(t, 2, len(queryDefinitions))
-}
-
-func Test_generateInstanceDefinitions92(t *testing.T) {
-	v := semver.MustParse("9.2.0")
-	queryDefinitions := generateInstanceDefinitions(&v)
-
-	assert.Equal(t, 3, len(queryDefinitions))
-}
-
-func Test_generateInstanceDefinitions10(t *testing.T) {
-	v := semver.MustParse("10.2.0")
-	queryDefinitions := generateInstanceDefinitions(&v)
-
-	assert.Equal(t, 3, len(queryDefinitions))
-}
-
-func Test_generateInstanceDefinitions170(t *testing.T) {
-	v := semver.MustParse("17.0.0")
-	queryDefinitions := generateInstanceDefinitions(&v)
-
-	assert.Equal(t, 2, len(queryDefinitions))
-}
-
-func Test_generateInstanceDefinitions175(t *testing.T) {
-	v := semver.MustParse("17.5.0")
-	queryDefinitions := generateInstanceDefinitions(&v)
-
-	assert.Equal(t, 2, len(queryDefinitions))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			version := semver.MustParse(tt.version)
+			queryDefinitions := generateInstanceDefinitions(&version)
+			assert.Equal(t, tt.expectedLength, len(queryDefinitions))
+		})
+	}
 }

--- a/src/metrics/instance_definitions_test.go
+++ b/src/metrics/instance_definitions_test.go
@@ -39,12 +39,12 @@ func Test_generateInstanceDefinitions170(t *testing.T) {
 	v := semver.MustParse("17.0.0")
 	queryDefinitions := generateInstanceDefinitions(&v)
 
-	assert.Equal(t, 5, len(queryDefinitions))
+	assert.Equal(t, 2, len(queryDefinitions))
 }
 
 func Test_generateInstanceDefinitions175(t *testing.T) {
 	v := semver.MustParse("17.5.0")
 	queryDefinitions := generateInstanceDefinitions(&v)
 
-	assert.Equal(t, 5, len(queryDefinitions))
+	assert.Equal(t, 2, len(queryDefinitions))
 }

--- a/src/metrics/instance_definitions_test.go
+++ b/src/metrics/instance_definitions_test.go
@@ -62,7 +62,7 @@ func Test_generateInstanceDefinitionsOutOfOrder(t *testing.T) {
 		queryDefinitions := generateInstanceDefinitions(&version)
 		expectedQueries := []*QueryDefinition{instanceDefinitionInputOutput170, instanceDefinition170, instanceDefinitionBase170}
 
-		// This fails beacuse order is different
+		// This fails because order is different
 		assert.False(t, assert.ObjectsAreEqual(expectedQueries, queryDefinitions), "Query definitions should be in the correct order")
 	})
 }

--- a/src/metrics/instance_definitions_test.go
+++ b/src/metrics/instance_definitions_test.go
@@ -12,49 +12,36 @@ func Test_generateInstanceDefinitions(t *testing.T) {
 		name            string
 		version         string
 		expectedQueries []*QueryDefinition
-		errorExpected   bool
 	}{
 		{
 			name:            "PostgreSQL 9.0",
 			version:         "9.0.0",
 			expectedQueries: []*QueryDefinition{instanceDefinitionBase},
-			errorExpected:   false,
 		},
 		{
 			name:            "PostgreSQL 9.1",
 			version:         "9.1.0",
 			expectedQueries: []*QueryDefinition{instanceDefinitionBase, instanceDefinition91},
-			errorExpected:   false,
 		},
 		{
 			name:            "PostgreSQL 9.2",
 			version:         "9.2.0",
 			expectedQueries: []*QueryDefinition{instanceDefinitionBase, instanceDefinition91, instanceDefinition92},
-			errorExpected:   false,
 		},
 		{
 			name:            "PostgreSQL 10.2",
 			version:         "10.2.0",
 			expectedQueries: []*QueryDefinition{instanceDefinitionBase, instanceDefinition91, instanceDefinition92},
-			errorExpected:   false,
 		},
 		{
 			name:            "PostgreSQL 16.4",
 			version:         "16.4.2",
 			expectedQueries: []*QueryDefinition{instanceDefinitionBase, instanceDefinition91, instanceDefinition92},
-			errorExpected:   false,
 		},
 		{
 			name:            "PostgreSQL 17.0",
 			version:         "17.0.0",
 			expectedQueries: []*QueryDefinition{instanceDefinitionBase170, instanceDefinition170, instanceDefinitionInputOutput170},
-			errorExpected:   false,
-		},
-		{
-			name:            "PostgreSQL 17.5 out of order",
-			version:         "17.5.0",
-			expectedQueries: []*QueryDefinition{instanceDefinition170, instanceDefinitionInputOutput170, instanceDefinitionBase170},
-			errorExpected:   true,
 		},
 	}
 
@@ -63,12 +50,19 @@ func Test_generateInstanceDefinitions(t *testing.T) {
 			version := semver.MustParse(tt.version)
 			queryDefinitions := generateInstanceDefinitions(&version)
 			assert.Equal(t, len(tt.expectedQueries), len(queryDefinitions))
-
-			if tt.errorExpected {
-				assert.False(t, assert.ObjectsAreEqual(tt.expectedQueries, queryDefinitions))
-			} else {
-				assert.ElementsMatch(t, tt.expectedQueries, queryDefinitions)
-			}
+			assert.Equal(t, tt.expectedQueries, queryDefinitions)
 		})
 	}
+
+}
+
+func Test_generateInstanceDefinitionsOutOfOrder(t *testing.T) {
+	t.Run("PostgreSQL 17.5 order check", func(t *testing.T) {
+		version := semver.MustParse("17.5.0")
+		queryDefinitions := generateInstanceDefinitions(&version)
+		expectedQueries := []*QueryDefinition{instanceDefinitionInputOutput170, instanceDefinition170, instanceDefinitionBase170}
+
+		// This fails beacuse order is different
+		assert.False(t, assert.ObjectsAreEqual(expectedQueries, queryDefinitions), "Query definitions should be in the correct order")
+	})
 }

--- a/src/metrics/instance_definitions_test.go
+++ b/src/metrics/instance_definitions_test.go
@@ -34,3 +34,17 @@ func Test_generateInstanceDefinitions10(t *testing.T) {
 
 	assert.Equal(t, 3, len(queryDefinitions))
 }
+
+func Test_generateInstanceDefinitions170(t *testing.T) {
+	v := semver.MustParse("17.0.0")
+	queryDefinitions := generateInstanceDefinitions(&v)
+
+	assert.Equal(t, 5, len(queryDefinitions))
+}
+
+func Test_generateInstanceDefinitions175(t *testing.T) {
+	v := semver.MustParse("17.5.0")
+	queryDefinitions := generateInstanceDefinitions(&v)
+
+	assert.Equal(t, 5, len(queryDefinitions))
+}

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_DB: demo
 
   postgres-latest-supported:
-    image: postgres:16
+    image: postgres:17.0
     restart: always
     environment:
       POSTGRES_USER: postgres

--- a/tests/testdata/jsonschema-inventory-latest.json
+++ b/tests/testdata/jsonschema-inventory-latest.json
@@ -11843,6 +11843,426 @@
                 "required": [
                   "value"
                 ]
+              },
+              "allow_alter_system/boot_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "allow_alter_system/reset_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "allow_alter_system/setting": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "commit_timestamp_buffers/boot_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "commit_timestamp_buffers/reset_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "commit_timestamp_buffers/setting": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "enable_group_by_reordering/boot_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "enable_group_by_reordering/reset_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "enable_group_by_reordering/setting": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "event_triggers/boot_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "event_triggers/reset_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "event_triggers/setting": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "huge_pages_status/boot_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "huge_pages_status/reset_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "huge_pages_status/setting": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "io_combine_limit/boot_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "io_combine_limit/reset_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "io_combine_limit/setting": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "max_notify_queue_pages/boot_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "max_notify_queue_pages/reset_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "max_notify_queue_pages/setting": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "multixact_member_buffers/boot_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "multixact_member_buffers/reset_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "multixact_member_buffers/setting": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "multixact_offset_buffers/boot_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "multixact_offset_buffers/reset_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "multixact_offset_buffers/setting": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "notify_buffers/boot_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "notify_buffers/reset_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "notify_buffers/setting": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "restrict_nonsystem_relation_kind/boot_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "restrict_nonsystem_relation_kind/reset_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "restrict_nonsystem_relation_kind/setting": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "serializable_buffers/boot_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "serializable_buffers/reset_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "serializable_buffers/setting": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "subtransaction_buffers/boot_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "subtransaction_buffers/reset_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "subtransaction_buffers/setting": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "summarize_wal/boot_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "summarize_wal/reset_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "summarize_wal/setting": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "sync_replication_slots/boot_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "sync_replication_slots/reset_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "sync_replication_slots/setting": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "synchronized_standby_slots/boot_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "synchronized_standby_slots/reset_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "synchronized_standby_slots/setting": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "trace_connection_negotiation/boot_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "trace_connection_negotiation/reset_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "trace_connection_negotiation/setting": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "transaction_buffers/boot_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "transaction_buffers/reset_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "transaction_buffers/setting": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "transaction_timeout/boot_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "transaction_timeout/reset_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "transaction_timeout/setting": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "wal_summary_keep_time/boot_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "wal_summary_keep_time/reset_val": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
+              },
+              "wal_summary_keep_time/setting": {
+                "type": "object",
+                "properties": {
+                  "value": {"type": "string"}
+                },
+                "required": ["value"]
               }
             },
             "required": [
@@ -12919,7 +13339,67 @@
               "xmloption/setting",
               "zero_damaged_pages/boot_val",
               "zero_damaged_pages/reset_val",
-              "zero_damaged_pages/setting"
+              "zero_damaged_pages/setting",
+              "allow_alter_system/boot_val",
+              "allow_alter_system/reset_val",
+              "allow_alter_system/setting",
+              "commit_timestamp_buffers/boot_val",
+              "commit_timestamp_buffers/reset_val",
+              "commit_timestamp_buffers/setting",
+              "enable_group_by_reordering/boot_val",
+              "enable_group_by_reordering/reset_val",
+              "enable_group_by_reordering/setting",
+              "event_triggers/boot_val",
+              "event_triggers/reset_val",
+              "event_triggers/setting",
+              "huge_pages_status/boot_val",
+              "huge_pages_status/reset_val",
+              "huge_pages_status/setting",
+              "io_combine_limit/boot_val",
+              "io_combine_limit/reset_val",
+              "io_combine_limit/setting",
+              "max_notify_queue_pages/boot_val",
+              "max_notify_queue_pages/reset_val",
+              "max_notify_queue_pages/setting",
+              "multixact_member_buffers/boot_val",
+              "multixact_member_buffers/reset_val",
+              "multixact_member_buffers/setting",
+              "multixact_offset_buffers/boot_val",
+              "multixact_offset_buffers/reset_val",
+              "multixact_offset_buffers/setting",
+              "notify_buffers/boot_val",
+              "notify_buffers/reset_val",
+              "notify_buffers/setting",
+              "restrict_nonsystem_relation_kind/boot_val",
+              "restrict_nonsystem_relation_kind/reset_val",
+              "restrict_nonsystem_relation_kind/setting",
+              "serializable_buffers/boot_val",
+              "serializable_buffers/reset_val",
+              "serializable_buffers/setting",
+              "subtransaction_buffers/boot_val",
+              "subtransaction_buffers/reset_val",
+              "subtransaction_buffers/setting",
+              "summarize_wal/boot_val",
+              "summarize_wal/reset_val",
+              "summarize_wal/setting",
+              "sync_replication_slots/boot_val",
+              "sync_replication_slots/reset_val",
+              "sync_replication_slots/setting",
+              "synchronized_standby_slots/boot_val",
+              "synchronized_standby_slots/reset_val",
+              "synchronized_standby_slots/setting",
+              "trace_connection_negotiation/boot_val",
+              "trace_connection_negotiation/reset_val",
+              "trace_connection_negotiation/setting",
+              "transaction_buffers/boot_val",
+              "transaction_buffers/reset_val",
+              "transaction_buffers/setting",
+              "transaction_timeout/boot_val",
+              "transaction_timeout/reset_val",
+              "transaction_timeout/setting",
+              "wal_summary_keep_time/boot_val",
+              "wal_summary_keep_time/reset_val",
+              "wal_summary_keep_time/setting"
             ]
           },
           "events": {

--- a/tests/testdata/jsonschema-inventory-latest.json
+++ b/tests/testdata/jsonschema-inventory-latest.json
@@ -2053,39 +2053,6 @@
                   "value"
                 ]
               },
-              "db_user_namespace/boot_val": {
-                "type": "object",
-                "properties": {
-                  "value": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "value"
-                ]
-              },
-              "db_user_namespace/reset_val": {
-                "type": "object",
-                "properties": {
-                  "value": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "value"
-                ]
-              },
-              "db_user_namespace/setting": {
-                "type": "object",
-                "properties": {
-                  "value": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "value"
-                ]
-              },
               "deadlock_timeout/boot_val": {
                 "type": "object",
                 "properties": {
@@ -7490,39 +7457,6 @@
                   "value"
                 ]
               },
-              "old_snapshot_threshold/boot_val": {
-                "type": "object",
-                "properties": {
-                  "value": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "value"
-                ]
-              },
-              "old_snapshot_threshold/reset_val": {
-                "type": "object",
-                "properties": {
-                  "value": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "value"
-                ]
-              },
-              "old_snapshot_threshold/setting": {
-                "type": "object",
-                "properties": {
-                  "value": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "value"
-                ]
-              },
               "parallel_leader_participation/boot_val": {
                 "type": "object",
                 "properties": {
@@ -10194,39 +10128,6 @@
                   "value"
                 ]
               },
-              "trace_recovery_messages/boot_val": {
-                "type": "object",
-                "properties": {
-                  "value": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "value"
-                ]
-              },
-              "trace_recovery_messages/reset_val": {
-                "type": "object",
-                "properties": {
-                  "value": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "value"
-                ]
-              },
-              "trace_recovery_messages/setting": {
-                "type": "object",
-                "properties": {
-                  "value": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "value"
-                ]
-              },
               "trace_sort/boot_val": {
                 "type": "object",
                 "properties": {
@@ -12128,9 +12029,6 @@
               "data_sync_retry/boot_val",
               "data_sync_retry/reset_val",
               "data_sync_retry/setting",
-              "db_user_namespace/boot_val",
-              "db_user_namespace/reset_val",
-              "db_user_namespace/setting",
               "deadlock_timeout/boot_val",
               "deadlock_timeout/reset_val",
               "deadlock_timeout/setting",
@@ -12623,9 +12521,6 @@
               "min_wal_size/boot_val",
               "min_wal_size/reset_val",
               "min_wal_size/setting",
-              "old_snapshot_threshold/boot_val",
-              "old_snapshot_threshold/reset_val",
-              "old_snapshot_threshold/setting",
               "parallel_leader_participation/boot_val",
               "parallel_leader_participation/reset_val",
               "parallel_leader_participation/setting",
@@ -12869,9 +12764,6 @@
               "trace_notify/boot_val",
               "trace_notify/reset_val",
               "trace_notify/setting",
-              "trace_recovery_messages/boot_val",
-              "trace_recovery_messages/reset_val",
-              "trace_recovery_messages/setting",
               "trace_sort/boot_val",
               "trace_sort/reset_val",
               "trace_sort/setting",

--- a/tests/testdata/jsonschema-latest.json
+++ b/tests/testdata/jsonschema-latest.json
@@ -100,6 +100,12 @@
                 "checkpointer.checkpointsScheduledPerSecond": {
                   "type": "number"
                 },
+                "io.backendFsyncCallsPerSecond": {
+                  "type": "number"
+                },
+                "io.buffersWrittenByBackendPerSecond": {
+                  "type": "number"
+                },
                 "displayName": {
                   "type": "string"
                 },

--- a/tests/testdata/jsonschema-latest.json
+++ b/tests/testdata/jsonschema-latest.json
@@ -85,6 +85,21 @@
                 "bgwriter.checkpointsScheduledPerSecond": {
                   "type": "number"
                 },
+                "checkpointer.buffersWrittenForCheckpointsPerSecond": {
+                  "type": "number"
+                },
+                "checkpointer.checkpointSyncTimeInMillisecondsPerSecond": {
+                  "type": "number"
+                },
+                "checkpointer.checkpointWriteTimeInMillisecondsPerSecond": {
+                  "type": "number"
+                },
+                "checkpointer.checkpointsRequestedPerSecond": {
+                  "type": "number"
+                },
+                "checkpointer.checkpointsScheduledPerSecond": {
+                  "type": "number"
+                },
                 "displayName": {
                   "type": "string"
                 },


### PR DESCRIPTION
Postgres 17 introduced a new table `pg_stat_checkpointer`
Metrics originally being collected from `pg_stat_bgwriter` were moved to `pg_stat_checkpointer`
Queries were modified to collect the metrics from the new table.
Two metrics `buffers_backend` and `buffers_backend_fsync` were dropped in Postgres 17. (https://pgpedia.info/p/pg_stat_bgwriter.html) and are no longer available.

The schema and inventory JSONs for the integration tests were modified to reflect the new metric names and modified inventory variables.

Instance definitions were version dependent. A new way to manage version dependence was created in order to future proof.
