### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,6 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
-## v2.16.1 - 2024-12-16
-
-### ⛓️ Dependencies
-- Updated golang patch version to v1.23.4
-
 ## v2.16.0 - 2024-11-11
 
 ### 🚀 Enhancements


### PR DESCRIPTION
Revert changelog to retrigger the prerelease of Renovate bumps