### PR TITLE
Feat : Query monitoring tech debt (#78)

### DIFF
--- a/postgresql-config.yml.sample
+++ b/postgresql-config.yml.sample
@@ -50,6 +50,9 @@ integrations:
     # True if SSL is to be used. Defaults to false.
     ENABLE_SSL: "false"
 
+    # Enable collection of only detailed query performance metrics, excluding other metrics. - Defaults to false
+    QUERY_MONITORING_ONLY : "false"
+
     # Enable query performance monitoring - Defaults to false
     # ENABLE_QUERY_MONITORING : "false"
 

--- a/src/args/argument_list.go
+++ b/src/args/argument_list.go
@@ -31,6 +31,7 @@ type ArgumentList struct {
 	CollectBloatMetrics                  bool   `default:"true" help:"Enable collecting bloat metrics which can be performance intensive"`
 	ShowVersion                          bool   `default:"false" help:"Print build information and exit"`
 	EnableQueryMonitoring                bool   `default:"false" help:"Enable collection of detailed query performance metrics."`
+	QueryMonitoringOnly                  bool   `default:"false" help:"Enable only collection of detailed query performance metrics."`
 	QueryMonitoringResponseTimeThreshold int    `default:"500" help:"Threshold in milliseconds for query response time. If response time for the individual query exceeds this threshold, the individual query is reported in metrics"`
 	QueryMonitoringCountThreshold        int    `default:"20" help:"The number of records for each query performance metrics"`
 }

--- a/src/args/argument_list.go
+++ b/src/args/argument_list.go
@@ -31,7 +31,7 @@ type ArgumentList struct {
 	CollectBloatMetrics                  bool   `default:"true" help:"Enable collecting bloat metrics which can be performance intensive"`
 	ShowVersion                          bool   `default:"false" help:"Print build information and exit"`
 	EnableQueryMonitoring                bool   `default:"false" help:"Enable collection of detailed query performance metrics."`
-	QueryMonitoringOnly                  bool   `default:"false" help:"Enable only collection of detailed query performance metrics."`
+	QueryMonitoringOnly                  bool   `default:"false" help:"Enable collection of only detailed query performance metrics, excluding other metrics."`
 	QueryMonitoringResponseTimeThreshold int    `default:"500" help:"Threshold in milliseconds for query response time. If response time for the individual query exceeds this threshold, the individual query is reported in metrics"`
 	QueryMonitoringCountThreshold        int    `default:"20" help:"The number of records for each query performance metrics"`
 }

--- a/src/main.go
+++ b/src/main.go
@@ -71,6 +71,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if args.QueryMonitoringOnly && args.EnableQueryMonitoring {
+		queryperformancemonitoring.QueryPerformanceMain(args, pgIntegration, collectionList)
+		return
+	}
+
 	if args.HasMetrics() {
 		metrics.PopulateMetrics(connectionInfo, collectionList, instance, pgIntegration, args.Pgbouncer, args.CollectDbLockMetrics, args.CollectBloatMetrics, args.CustomMetricsQuery)
 		if args.CustomMetricsConfig != "" {

--- a/src/main.go
+++ b/src/main.go
@@ -71,7 +71,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if args.QueryMonitoringOnly && args.EnableQueryMonitoring {
+	if args.QueryMonitoringOnly {
 		queryperformancemonitoring.QueryPerformanceMain(args, pgIntegration, collectionList)
 		return
 	}

--- a/src/query-performance-monitoring/common-utils/ingestion-helpers.go
+++ b/src/query-performance-monitoring/common-utils/ingestion-helpers.go
@@ -2,37 +2,11 @@ package commonutils
 
 import (
 	"fmt"
-	"reflect"
-
 	commonparameters "github.com/newrelic/nri-postgresql/src/query-performance-monitoring/common-parameters"
 
-	"github.com/newrelic/infra-integrations-sdk/v3/data/metric"
 	"github.com/newrelic/infra-integrations-sdk/v3/integration"
 	"github.com/newrelic/infra-integrations-sdk/v3/log"
 )
-
-func SetMetric(metricSet *metric.Set, name string, value interface{}, sourceType string) {
-	switch sourceType {
-	case `gauge`:
-		err := metricSet.SetMetric(name, value, metric.GAUGE)
-		if err != nil {
-			log.Error("Error setting metric: %v", err)
-			return
-		}
-	case `attribute`:
-		err := metricSet.SetMetric(name, value, metric.ATTRIBUTE)
-		if err != nil {
-			log.Error("Error setting metric: %v", err)
-			return
-		}
-	default:
-		err := metricSet.SetMetric(name, value, metric.GAUGE)
-		if err != nil {
-			log.Error("Error setting metric: %v", err)
-			return
-		}
-	}
-}
 
 // IngestMetric is a util by which we publish data in batches .Reason for this is to avoid publishing large data in one go and its a limitation for NewRelic.
 func IngestMetric(metricList []interface{}, eventName string, pgIntegration *integration.Integration, cp *commonparameters.CommonParameters) error {
@@ -41,22 +15,18 @@ func IngestMetric(metricList []interface{}, eventName string, pgIntegration *int
 		log.Error("Error creating entity: %v", err)
 		return err
 	}
-
 	metricCount := 0
-
 	for _, model := range metricList {
 		if model == nil {
 			continue
 		}
 		metricCount += 1
 		metricSet := instanceEntity.NewMetricSet(eventName)
-
-		processErr := ProcessModel(model, metricSet)
-		if processErr != nil {
-			log.Error("Error processing model: %v", processErr)
+		marshalErr := metricSet.MarshalMetrics(model)
+		if marshalErr != nil {
+			log.Error("Error processing model: %v", marshalErr)
 			continue
 		}
-
 		if metricCount == PublishThreshold {
 			metricCount = 0
 			if err := PublishMetrics(pgIntegration, &instanceEntity, cp); err != nil {
@@ -78,40 +48,9 @@ func CreateEntity(pgIntegration *integration.Integration, cp *commonparameters.C
 	return pgIntegration.Entity(fmt.Sprintf("%s:%s", cp.Host, cp.Port), "pg-instance")
 }
 
-func ProcessModel(model interface{}, metricSet *metric.Set) error {
-	modelValue := reflect.ValueOf(model)
-	if modelValue.Kind() == reflect.Ptr {
-		modelValue = modelValue.Elem()
-	}
-	if !modelValue.IsValid() || modelValue.Kind() != reflect.Struct {
-		log.Error("Invalid model type: %v", modelValue.Kind())
-		return ErrInvalidModelType
-	}
-
-	modelType := reflect.TypeOf(model)
-
-	for i := 0; i < modelValue.NumField(); i++ {
-		field := modelValue.Field(i)
-		fieldType := modelType.Field(i)
-		metricName := fieldType.Tag.Get("metric_name")
-		sourceType := fieldType.Tag.Get("source_type")
-		ingestData := fieldType.Tag.Get("ingest_data")
-
-		if ingestData == "false" {
-			continue
-		}
-
-		if field.Kind() == reflect.Ptr && !field.IsNil() {
-			SetMetric(metricSet, metricName, field.Elem().Interface(), sourceType)
-		} else if field.Kind() != reflect.Ptr {
-			SetMetric(metricSet, metricName, field.Interface(), sourceType)
-		}
-	}
-	return nil
-}
-
 func PublishMetrics(pgIntegration *integration.Integration, instanceEntity **integration.Entity, cp *commonparameters.CommonParameters) error {
 	if err := pgIntegration.Publish(); err != nil {
+		log.Error("Error publishing query performance metrics")
 		return err
 	}
 	var err error

--- a/src/query-performance-monitoring/common-utils/ingestion_helper_test.go
+++ b/src/query-performance-monitoring/common-utils/ingestion_helper_test.go
@@ -3,7 +3,7 @@ package commonutils_test
 import (
 	"testing"
 
-	common_parameters "github.com/newrelic/nri-postgresql/src/query-performance-monitoring/common-parameters"
+	commonparameters "github.com/newrelic/nri-postgresql/src/query-performance-monitoring/common-parameters"
 
 	"github.com/newrelic/infra-integrations-sdk/v3/integration"
 	"github.com/newrelic/nri-postgresql/src/args"
@@ -11,25 +11,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSetMetric(t *testing.T) {
-	pgIntegration, _ := integration.New("test", "1.0.0")
-	entity, _ := pgIntegration.Entity("test-entity", "test-type")
-	metricSet := entity.NewMetricSet("test-event")
-	commonutils.SetMetric(metricSet, "testGauge", 123.0, "gauge")
-	assert.Equal(t, 123.0, metricSet.Metrics["testGauge"])
-	commonutils.SetMetric(metricSet, "testAttribute", "value", "attribute")
-	assert.Equal(t, "value", metricSet.Metrics["testAttribute"])
-	commonutils.SetMetric(metricSet, "testDefault", 456.0, "unknown")
-	assert.Equal(t, 456.0, metricSet.Metrics["testDefault"])
-}
-
 func TestIngestMetric(t *testing.T) {
 	pgIntegration, _ := integration.New("test", "1.0.0")
 	args := args.ArgumentList{
 		Hostname: "localhost",
 		Port:     "5432",
 	}
-	cp := common_parameters.SetCommonParameters(args, uint64(14), "testdb")
+	cp := commonparameters.SetCommonParameters(args, uint64(14), "testdb")
 	metricList := []interface{}{
 		struct {
 			TestField int `metric_name:"testField" source_type:"gauge"`
@@ -49,27 +37,12 @@ func TestCreateEntity(t *testing.T) {
 		Hostname: "localhost",
 		Port:     "5432",
 	}
-	cp := common_parameters.SetCommonParameters(args, uint64(14), "testdb")
+	cp := commonparameters.SetCommonParameters(args, uint64(14), "testdb")
 
 	entity, err := commonutils.CreateEntity(pgIntegration, cp)
 	assert.NoError(t, err)
 	assert.NotNil(t, entity)
 	assert.Equal(t, "localhost:5432", entity.Metadata.Name)
-}
-
-func TestProcessModel(t *testing.T) {
-	pgIntegration, _ := integration.New("test", "1.0.0")
-	entity, _ := pgIntegration.Entity("test-entity", "test-type")
-
-	metricSet := entity.NewMetricSet("test-event")
-
-	model := struct {
-		TestField int `metric_name:"testField" source_type:"gauge"`
-	}{TestField: 123}
-
-	err := commonutils.ProcessModel(model, metricSet)
-	assert.NoError(t, err)
-	assert.Equal(t, 123.0, metricSet.Metrics["testField"])
 }
 
 func TestPublishMetrics(t *testing.T) {
@@ -78,7 +51,7 @@ func TestPublishMetrics(t *testing.T) {
 		Hostname: "localhost",
 		Port:     "5432",
 	}
-	cp := common_parameters.SetCommonParameters(args, uint64(14), "testdb")
+	cp := commonparameters.SetCommonParameters(args, uint64(14), "testdb")
 	entity, _ := commonutils.CreateEntity(pgIntegration, cp)
 
 	err := commonutils.PublishMetrics(pgIntegration, &entity, cp)

--- a/src/query-performance-monitoring/datamodels/performance_data_models.go
+++ b/src/query-performance-monitoring/datamodels/performance_data_models.go
@@ -1,7 +1,6 @@
 package datamodels
 
 type SlowRunningQueryMetrics struct {
-	Newrelic            *string  `db:"newrelic"              metric_name:"newrelic"                   source_type:"attribute"  ingest_data:"false"`
 	QueryID             *string  `db:"query_id"              metric_name:"query_id"                   source_type:"attribute"`
 	QueryText           *string  `db:"query_text"            metric_name:"query_text"                 source_type:"attribute"`
 	DatabaseName        *string  `db:"database_name"         metric_name:"database_name"              source_type:"attribute"`
@@ -23,7 +22,6 @@ type WaitEventMetrics struct {
 	DatabaseName        *string  `db:"database_name"         metric_name:"database_name"              source_type:"attribute"`
 }
 type BlockingSessionMetrics struct {
-	Newrelic           *string `db:"newrelic"              metric_name:"newrelic"            source_type:"attribute"  ingest_data:"false"`
 	BlockedPid         *int64  `db:"blocked_pid"          metric_name:"blocked_pid"          source_type:"gauge"`
 	BlockedQuery       *string `db:"blocked_query"        metric_name:"blocked_query"        source_type:"attribute"`
 	BlockedQueryID     *string `db:"blocked_query_id"     metric_name:"blocked_query_id"     source_type:"attribute"`
@@ -36,14 +34,19 @@ type BlockingSessionMetrics struct {
 }
 
 type IndividualQueryMetrics struct {
-	QueryText       *string  `json:"query" db:"query" metric_name:"query_text" source_type:"attribute"`
-	QueryID         *string  `json:"queryid" db:"queryid" metric_name:"query_id" source_type:"attribute"`
-	DatabaseName    *string  `json:"datname" db:"datname" metric_name:"database_name" source_type:"attribute"`
-	AvgCPUTimeInMS  *float64 `json:"cpu_time_ms" db:"cpu_time_ms" metric_name:"cpu_time_ms" source_type:"gauge"`
-	PlanID          *string  `json:"planid" db:"planid" metric_name:"plan_id" source_type:"attribute"`
-	RealQueryText   *string  `ingest_data:"false"`
-	AvgExecTimeInMs *float64 `json:"exec_time_ms" db:"exec_time_ms" metric_name:"exec_time_ms" source_type:"gauge"`
-	Newrelic        *string  `db:"newrelic"              metric_name:"newrelic"            source_type:"attribute"  ingest_data:"false"`
+	QueryText    *string  `json:"query" db:"query" metric_name:"query_text" source_type:"attribute"`
+	QueryID      *string  `json:"queryid" db:"queryid" metric_name:"query_id" source_type:"attribute"`
+	DatabaseName *string  `json:"datname" db:"datname" metric_name:"database_name" source_type:"attribute"`
+	CPUTimeInMS  *float64 `json:"cpu_time_ms" db:"cpu_time_ms" metric_name:"cpu_time_ms" source_type:"gauge"`
+	PlanID       *string  `json:"planid" db:"planid" metric_name:"plan_id" source_type:"attribute"`
+	ExecTimeInMs *float64 `json:"exec_time_ms" db:"exec_time_ms" metric_name:"exec_time_ms" source_type:"gauge"`
+}
+
+type IndividualQueryInfo struct {
+	QueryID       *string
+	DatabaseName  *string
+	PlanID        *string
+	RealQueryText *string
 }
 
 type QueryExecutionPlanMetrics struct {

--- a/src/query-performance-monitoring/performance-metrics/blocking_sessions.go
+++ b/src/query-performance-monitoring/performance-metrics/blocking_sessions.go
@@ -17,16 +17,16 @@ import (
 func PopulateBlockingMetrics(conn *performancedbconnection.PGSQLConnection, pgIntegration *integration.Integration, cp *commonparameters.CommonParameters, enabledExtensions map[string]bool) {
 	isEligible, enableCheckError := validations.CheckBlockingSessionMetricsFetchEligibility(enabledExtensions, cp.Version)
 	if enableCheckError != nil {
-		log.Error("Error executing query: %v in PopulateBlockingMetrics", enableCheckError)
+		log.Error("Error executing query for eligibility check in PopulateBlockingMetrics: %v", enableCheckError)
 		return
 	}
 	if !isEligible {
 		log.Debug("Extension 'pg_stat_statements' is not enabled or unsupported version.")
 		return
 	}
-	blockingQueriesMetricsList, blockQueryFetchErr := getBlockingMetrics(conn, cp)
-	if blockQueryFetchErr != nil {
-		log.Error("Error fetching Blocking queries: %v", blockQueryFetchErr)
+	blockingQueriesMetricsList, blockQueryMetricsFetchErr := getBlockingMetrics(conn, cp)
+	if blockQueryMetricsFetchErr != nil {
+		log.Error("Error fetching blocking queries: %v", blockQueryMetricsFetchErr)
 		return
 	}
 	if len(blockingQueriesMetricsList) == 0 {
@@ -35,37 +35,33 @@ func PopulateBlockingMetrics(conn *performancedbconnection.PGSQLConnection, pgIn
 	}
 	err := commonutils.IngestMetric(blockingQueriesMetricsList, "PostgresBlockingSessions", pgIntegration, cp)
 	if err != nil {
-		log.Error("Error ingesting Blocking queries: %v", err)
+		log.Error("Error ingesting blocking queries: %v", err)
 		return
 	}
+	log.Debug("Successfully ingested blocking metrics ")
 }
 
 func getBlockingMetrics(conn *performancedbconnection.PGSQLConnection, cp *commonparameters.CommonParameters) ([]interface{}, error) {
-	var blockingQueriesMetricsList []interface{}
 	versionSpecificBlockingQuery, err := commonutils.FetchVersionSpecificBlockingQueries(cp.Version)
 	if err != nil {
 		log.Error("Unsupported postgres version: %v", err)
 		return nil, err
 	}
-	var query = fmt.Sprintf(versionSpecificBlockingQuery, cp.Databases, cp.QueryMonitoringCountThreshold)
-	rows, err := conn.Queryx(query)
+	query := fmt.Sprintf(versionSpecificBlockingQuery, cp.Databases, cp.QueryMonitoringCountThreshold)
+	blockingQueriesMetricsList, _, err := fetchMetrics[datamodels.BlockingSessionMetrics](conn, query, "Blocking Query")
 	if err != nil {
-		log.Error("Failed to execute query: %v", err)
+		log.Error("Error fetching blocking queries: %v", err)
 		return nil, commonutils.ErrUnExpectedError
 	}
-	defer rows.Close()
-	for rows.Next() {
-		var blockingQueryMetric datamodels.BlockingSessionMetrics
-		if scanError := rows.StructScan(&blockingQueryMetric); scanError != nil {
-			return nil, scanError
+	if cp.Version == commonutils.PostgresVersion13 || cp.Version == commonutils.PostgresVersion12 {
+		for i := range blockingQueriesMetricsList {
+			*blockingQueriesMetricsList[i].BlockedQuery = commonutils.AnonymizeQueryText(*blockingQueriesMetricsList[i].BlockedQuery)
+			*blockingQueriesMetricsList[i].BlockingQuery = commonutils.AnonymizeQueryText(*blockingQueriesMetricsList[i].BlockingQuery)
 		}
-		// For PostgreSQL versions 13 and 12, anonymization of queries does not occur for blocking sessions, so it's necessary to explicitly anonymize them.
-		if cp.Version == commonutils.PostgresVersion13 || cp.Version == commonutils.PostgresVersion12 {
-			*blockingQueryMetric.BlockedQuery = commonutils.AnonymizeQueryText(*blockingQueryMetric.BlockedQuery)
-			*blockingQueryMetric.BlockingQuery = commonutils.AnonymizeQueryText(*blockingQueryMetric.BlockingQuery)
-		}
-		blockingQueriesMetricsList = append(blockingQueriesMetricsList, blockingQueryMetric)
 	}
-
-	return blockingQueriesMetricsList, nil
+	var blockingQueriesMetricsListInterface = make([]interface{}, 0)
+	for _, metric := range blockingQueriesMetricsList {
+		blockingQueriesMetricsListInterface = append(blockingQueriesMetricsListInterface, metric)
+	}
+	return blockingQueriesMetricsListInterface, nil
 }

--- a/src/query-performance-monitoring/performance-metrics/execution_plan_metrics.go
+++ b/src/query-performance-monitoring/performance-metrics/execution_plan_metrics.go
@@ -46,7 +46,7 @@ func getExecutionPlanMetrics(results []datamodels.IndividualQueryInfo, connectio
 func processExecutionPlanOfQueries(individualQueriesList []datamodels.IndividualQueryInfo, dbConn *performancedbconnection.PGSQLConnection, executionPlanMetricsList *[]interface{}) {
 	for _, individualQuery := range individualQueriesList {
 		if individualQuery.RealQueryText == nil || individualQuery.QueryID == nil || individualQuery.DatabaseName == nil {
-			log.Error("QueryText, QueryID or Database Name is nil for query: %+v", individualQuery)
+			log.Error("QueryText, QueryID or Database Name is nil")
 			continue
 		}
 		query := "EXPLAIN (FORMAT JSON) " + *individualQuery.RealQueryText

--- a/src/query-performance-monitoring/performance-metrics/execution_plan_metrics.go
+++ b/src/query-performance-monitoring/performance-metrics/execution_plan_metrics.go
@@ -12,7 +12,7 @@ import (
 	"github.com/newrelic/nri-postgresql/src/query-performance-monitoring/datamodels"
 )
 
-func PopulateExecutionPlanMetrics(results []datamodels.IndividualQueryMetrics, pgIntegration *integration.Integration, cp *commonparameters.CommonParameters, connectionInfo performancedbconnection.Info) {
+func PopulateExecutionPlanMetrics(results []datamodels.IndividualQueryInfo, pgIntegration *integration.Integration, cp *commonparameters.CommonParameters, connectionInfo performancedbconnection.Info) {
 	if len(results) == 0 {
 		log.Debug("No individual queries found.")
 		return
@@ -23,44 +23,47 @@ func PopulateExecutionPlanMetrics(results []datamodels.IndividualQueryMetrics, p
 		log.Error("Error ingesting Execution Plan metrics: %v", err)
 		return
 	}
+	log.Debug("Successfully ingested execution plan metrics")
 }
 
-func getExecutionPlanMetrics(results []datamodels.IndividualQueryMetrics, connectionInfo performancedbconnection.Info) []interface{} {
+func getExecutionPlanMetrics(results []datamodels.IndividualQueryInfo, connectionInfo performancedbconnection.Info) []interface{} {
 	var executionPlanMetricsList []interface{}
-	var groupIndividualQueriesByDatabase = groupQueriesByDatabase(results)
-	for dbName, individualQueriesList := range groupIndividualQueriesByDatabase {
+	var databaseIndividualQueriesMap = groupQueriesByDatabase(results)
+	for dbName, individualQueriesList := range databaseIndividualQueriesMap {
 		dbConn, err := connectionInfo.NewConnection(dbName)
 		if err != nil {
-			log.Error("Error opening database connection: %v", err)
+			log.Error("Error opening database connection to %s: %v", dbName, err)
 			continue
 		}
 		processExecutionPlanOfQueries(individualQueriesList, dbConn, &executionPlanMetricsList)
 		dbConn.Close()
 	}
 
+	log.Debug("Fetched execution plan metrics for %d databases", len(databaseIndividualQueriesMap))
 	return executionPlanMetricsList
 }
 
-func processExecutionPlanOfQueries(individualQueriesList []datamodels.IndividualQueryMetrics, dbConn *performancedbconnection.PGSQLConnection, executionPlanMetricsList *[]interface{}) {
+func processExecutionPlanOfQueries(individualQueriesList []datamodels.IndividualQueryInfo, dbConn *performancedbconnection.PGSQLConnection, executionPlanMetricsList *[]interface{}) {
 	for _, individualQuery := range individualQueriesList {
 		if individualQuery.RealQueryText == nil || individualQuery.QueryID == nil || individualQuery.DatabaseName == nil {
-			log.Error("QueryText, QueryID or Database Name is nil")
+			log.Error("QueryText, QueryID or Database Name is nil for query: %+v", individualQuery)
 			continue
 		}
 		query := "EXPLAIN (FORMAT JSON) " + *individualQuery.RealQueryText
+		log.Info("Executing query: %s", query)
 		rows, err := dbConn.Queryx(query)
 		if err != nil {
-			log.Debug("Error executing query: %v", err)
+			log.Debug("Error executing query error: %v", err)
 			continue
 		}
 		defer rows.Close()
 		if !rows.Next() {
-			log.Debug("Execution plan not found for queryId", *individualQuery.QueryID)
+			log.Debug("Execution plan not found for queryId: %s", *individualQuery.QueryID)
 			continue
 		}
 		var execPlanJSON string
 		if scanErr := rows.Scan(&execPlanJSON); scanErr != nil {
-			log.Error("Error scanning row: ", scanErr.Error())
+			log.Error("Error scanning row for queryId  %v", scanErr)
 			continue
 		}
 
@@ -72,9 +75,10 @@ func processExecutionPlanOfQueries(individualQueriesList []datamodels.Individual
 		}
 		validateAndFetchNestedExecPlan(execPlan, individualQuery, executionPlanMetricsList)
 	}
+	log.Debug("Processed execution plans for %d queries", len(individualQueriesList))
 }
 
-func validateAndFetchNestedExecPlan(execPlan []map[string]interface{}, individualQuery datamodels.IndividualQueryMetrics, executionPlanMetricsList *[]interface{}) {
+func validateAndFetchNestedExecPlan(execPlan []map[string]interface{}, individualQuery datamodels.IndividualQueryInfo, executionPlanMetricsList *[]interface{}) {
 	level := 0
 	if len(execPlan) > 0 {
 		if plan, ok := execPlan[0]["Plan"].(map[string]interface{}); ok {
@@ -87,8 +91,8 @@ func validateAndFetchNestedExecPlan(execPlan []map[string]interface{}, individua
 	}
 }
 
-func groupQueriesByDatabase(results []datamodels.IndividualQueryMetrics) map[string][]datamodels.IndividualQueryMetrics {
-	databaseMap := make(map[string][]datamodels.IndividualQueryMetrics)
+func groupQueriesByDatabase(results []datamodels.IndividualQueryInfo) map[string][]datamodels.IndividualQueryInfo {
+	databaseMap := make(map[string][]datamodels.IndividualQueryInfo)
 	for _, individualQueryMetric := range results {
 		if individualQueryMetric.DatabaseName == nil {
 			continue
@@ -99,11 +103,11 @@ func groupQueriesByDatabase(results []datamodels.IndividualQueryMetrics) map[str
 	return databaseMap
 }
 
-func fetchNestedExecutionPlanDetails(individualQuery datamodels.IndividualQueryMetrics, level *int, execPlan map[string]interface{}, executionPlanMetricsList *[]interface{}) {
+func fetchNestedExecutionPlanDetails(individualQuery datamodels.IndividualQueryInfo, level *int, execPlan map[string]interface{}, executionPlanMetricsList *[]interface{}) {
 	var execPlanMetrics datamodels.QueryExecutionPlanMetrics
 	err := mapstructure.Decode(execPlan, &execPlanMetrics)
 	if err != nil {
-		log.Error("Failed to decode execPlan to execPlanMetrics: %v", err)
+		log.Error("Failed to decode execPlan to execPlanMetrics Error: %v", err)
 		return
 	}
 	execPlanMetrics.QueryID = *individualQuery.QueryID
@@ -119,4 +123,5 @@ func fetchNestedExecutionPlanDetails(individualQuery datamodels.IndividualQueryM
 			}
 		}
 	}
+	log.Debug("Fetched nested execution plan details")
 }

--- a/src/query-performance-monitoring/performance-metrics/execution_plan_metrics.go
+++ b/src/query-performance-monitoring/performance-metrics/execution_plan_metrics.go
@@ -50,7 +50,6 @@ func processExecutionPlanOfQueries(individualQueriesList []datamodels.Individual
 			continue
 		}
 		query := "EXPLAIN (FORMAT JSON) " + *individualQuery.RealQueryText
-		log.Info("Executing query: %s", query)
 		rows, err := dbConn.Queryx(query)
 		if err != nil {
 			log.Debug("Error executing query error: %v", err)
@@ -123,5 +122,4 @@ func fetchNestedExecutionPlanDetails(individualQuery datamodels.IndividualQueryI
 			}
 		}
 	}
-	log.Debug("Fetched nested execution plan details")
 }

--- a/src/query-performance-monitoring/performance-metrics/execution_plan_metrics_test.go
+++ b/src/query-performance-monitoring/performance-metrics/execution_plan_metrics_test.go
@@ -5,7 +5,7 @@ import (
 
 	performancedbconnection "github.com/newrelic/nri-postgresql/src/connection"
 
-	common_parameters "github.com/newrelic/nri-postgresql/src/query-performance-monitoring/common-parameters"
+	commonparameters "github.com/newrelic/nri-postgresql/src/query-performance-monitoring/common-parameters"
 
 	"github.com/newrelic/infra-integrations-sdk/v3/integration"
 	"github.com/newrelic/nri-postgresql/src/args"
@@ -16,8 +16,8 @@ import (
 func TestPopulateExecutionPlanMetrics(t *testing.T) {
 	pgIntegration, _ := integration.New("test", "1.0.0")
 	args := args.ArgumentList{}
-	results := []datamodels.IndividualQueryMetrics{}
-	cp := common_parameters.SetCommonParameters(args, uint64(13), "testdb")
+	results := []datamodels.IndividualQueryInfo{}
+	cp := commonparameters.SetCommonParameters(args, uint64(13), "testdb")
 	connectionInfo := performancedbconnection.DefaultConnectionInfo(&args)
 	PopulateExecutionPlanMetrics(results, pgIntegration, cp, connectionInfo)
 	assert.Empty(t, pgIntegration.Entities)
@@ -27,11 +27,11 @@ func TestGroupQueriesByDatabase(t *testing.T) {
 	databaseName := "testdb"
 	queryID := "queryid1"
 	queryText := "SELECT 1"
-	results := []datamodels.IndividualQueryMetrics{
+	results := []datamodels.IndividualQueryInfo{
 		{
-			QueryID:      &queryID,
-			QueryText:    &queryText,
-			DatabaseName: &databaseName,
+			QueryID:       &queryID,
+			RealQueryText: &queryText,
+			DatabaseName:  &databaseName,
 		},
 	}
 
@@ -46,11 +46,11 @@ func TestFetchNestedExecutionPlanDetails(t *testing.T) {
 	queryText := "SELECT 1"
 	databaseName := "testdb"
 	planID := "planid1"
-	individualQuery := datamodels.IndividualQueryMetrics{
-		QueryID:      &queryID,
-		QueryText:    &queryText,
-		DatabaseName: &databaseName,
-		PlanID:       &planID,
+	individualQuery := datamodels.IndividualQueryInfo{
+		QueryID:       &queryID,
+		RealQueryText: &queryText,
+		DatabaseName:  &databaseName,
+		PlanID:        &planID,
 	}
 	execPlan := map[string]interface{}{
 		"Node Type":     "Seq Scan",

--- a/src/query-performance-monitoring/performance-metrics/individual_query_metrics.go
+++ b/src/query-performance-monitoring/performance-metrics/individual_query_metrics.go
@@ -17,42 +17,43 @@ import (
 type queryInfoMap map[string]string
 type databaseQueryInfoMap map[string]queryInfoMap
 
-func PopulateIndividualQueryMetrics(conn *performancedbconnection.PGSQLConnection, slowRunningQueries []datamodels.SlowRunningQueryMetrics, pgIntegration *integration.Integration, cp *commonparameters.CommonParameters, enabledExtensions map[string]bool) []datamodels.IndividualQueryMetrics {
+func PopulateIndividualQueryMetrics(conn *performancedbconnection.PGSQLConnection, slowRunningQueries []datamodels.SlowRunningQueryMetrics, pgIntegration *integration.Integration, cp *commonparameters.CommonParameters, enabledExtensions map[string]bool) []datamodels.IndividualQueryInfo {
 	isEligible, err := validations.CheckIndividualQueryMetricsFetchEligibility(enabledExtensions)
 	if err != nil {
-		log.Error("Error executing query: %v", err)
-		return nil
+		log.Error("Error executing query for eligibility check: %v", err)
+		return []datamodels.IndividualQueryInfo{}
 	}
 	if !isEligible {
 		log.Debug("Extension 'pg_stat_monitor' is not enabled or unsupported version.")
-		return nil
+		return []datamodels.IndividualQueryInfo{}
 	}
 	log.Debug("Extension 'pg_stat_monitor' enabled.")
 	individualQueryMetricsInterface, individualQueriesList := getIndividualQueryMetrics(conn, slowRunningQueries, cp)
 	if len(individualQueryMetricsInterface) == 0 {
 		log.Debug("No individual queries found.")
-		return nil
+		return []datamodels.IndividualQueryInfo{}
 	}
 	err = commonutils.IngestMetric(individualQueryMetricsInterface, "PostgresIndividualQueries", pgIntegration, cp)
 	if err != nil {
 		log.Error("Error ingesting individual queries: %v", err)
-		return nil
+		return []datamodels.IndividualQueryInfo{}
 	}
+	log.Debug("Successfully ingested individual query metrics for databases")
 	return individualQueriesList
 }
 
-func getIndividualQueryMetrics(conn *performancedbconnection.PGSQLConnection, slowRunningQueries []datamodels.SlowRunningQueryMetrics, cp *commonparameters.CommonParameters) ([]interface{}, []datamodels.IndividualQueryMetrics) {
+func getIndividualQueryMetrics(conn *performancedbconnection.PGSQLConnection, slowRunningQueries []datamodels.SlowRunningQueryMetrics, cp *commonparameters.CommonParameters) ([]interface{}, []datamodels.IndividualQueryInfo) {
 	if len(slowRunningQueries) == 0 {
 		log.Debug("No slow running queries found.")
-		return nil, nil
+		return []interface{}{}, []datamodels.IndividualQueryInfo{}
 	}
-	var individualQueryMetricsList []datamodels.IndividualQueryMetrics
+	var individualQueryInfoList []datamodels.IndividualQueryInfo
 	var individualQueryMetricsListInterface []interface{}
 	anonymizedQueriesByDB := processForAnonymizeQueryMap(slowRunningQueries)
 	versionSpecificIndividualQuery, err := commonutils.FetchVersionSpecificIndividualQueries(cp.Version)
 	if err != nil {
 		log.Error("Unsupported postgres version: %v", err)
-		return nil, nil
+		return []interface{}{}, []datamodels.IndividualQueryInfo{}
 	}
 	for _, slowRunningMetric := range slowRunningQueries {
 		if slowRunningMetric.QueryID == nil {
@@ -62,24 +63,36 @@ func getIndividualQueryMetrics(conn *performancedbconnection.PGSQLConnection, sl
 		rows, err := conn.Queryx(query)
 		if err != nil {
 			log.Debug("Error executing query in individual query: %v", err)
-			return nil, nil
+			return []interface{}{}, []datamodels.IndividualQueryInfo{}
 		}
 		defer rows.Close()
-		individualQuerySamplesList := processRows(rows, anonymizedQueriesByDB)
+		individualQuerySamplesList := processRows(rows)
 		for _, individualQuery := range individualQuerySamplesList {
-			individualQueryMetricsList = append(individualQueryMetricsList, individualQuery)
+			individualQueryInfoList = append(individualQueryInfoList, setIndividualQueriesInfo(individualQuery))
+			anonymizedQueryText := anonymizedQueriesByDB[*individualQuery.DatabaseName][*individualQuery.QueryID]
+			individualQuery.QueryText = &anonymizedQueryText
 			individualQueryMetricsListInterface = append(individualQueryMetricsListInterface, individualQuery)
 		}
 	}
-	return individualQueryMetricsListInterface, individualQueryMetricsList
+	log.Debug("Fetched %d individual query metrics", len(individualQueryInfoList))
+	return individualQueryMetricsListInterface, individualQueryInfoList
 }
 
-func processRows(rows *sqlx.Rows, anonymizedQueriesByDB databaseQueryInfoMap) []datamodels.IndividualQueryMetrics {
+func setIndividualQueriesInfo(individualQueryMetrics datamodels.IndividualQueryMetrics) datamodels.IndividualQueryInfo {
+	return datamodels.IndividualQueryInfo{
+		DatabaseName:  individualQueryMetrics.DatabaseName,
+		QueryID:       individualQueryMetrics.QueryID,
+		PlanID:        individualQueryMetrics.PlanID,
+		RealQueryText: individualQueryMetrics.QueryText,
+	}
+}
+
+func processRows(rows *sqlx.Rows) []datamodels.IndividualQueryMetrics {
 	var individualQueryMetricsList []datamodels.IndividualQueryMetrics
 	for rows.Next() {
 		var model datamodels.IndividualQueryMetrics
 		if scanErr := rows.StructScan(&model); scanErr != nil {
-			log.Error("Could not scan row: ", scanErr)
+			log.Error("Could not scan row: %v", scanErr)
 			continue
 		}
 		if model.QueryID == nil || model.DatabaseName == nil {
@@ -87,10 +100,6 @@ func processRows(rows *sqlx.Rows, anonymizedQueriesByDB databaseQueryInfoMap) []
 			continue
 		}
 		individualQueryMetric := model
-		anonymizedQueryText := anonymizedQueriesByDB[*model.DatabaseName][*model.QueryID]
-		queryText := *model.QueryText
-		individualQueryMetric.RealQueryText = &queryText
-		individualQueryMetric.QueryText = &anonymizedQueryText
 		generatedPlanID, err := commonutils.GeneratePlanID()
 		if err != nil {
 			log.Error("Error generating plan ID: %v", err)
@@ -99,6 +108,7 @@ func processRows(rows *sqlx.Rows, anonymizedQueriesByDB databaseQueryInfoMap) []
 		individualQueryMetric.PlanID = &generatedPlanID
 		individualQueryMetricsList = append(individualQueryMetricsList, individualQueryMetric)
 	}
+	log.Debug("Processed %d rows into individual query metrics", len(individualQueryMetricsList))
 	return individualQueryMetricsList
 }
 

--- a/src/query-performance-monitoring/performance-metrics/individual_query_metrics_test.go
+++ b/src/query-performance-monitoring/performance-metrics/individual_query_metrics_test.go
@@ -1,13 +1,16 @@
 package performancemetrics
 
 import (
+	"database/sql/driver"
 	"fmt"
 	"regexp"
 	"testing"
 
+	"github.com/newrelic/infra-integrations-sdk/v3/integration"
+
 	"github.com/newrelic/nri-postgresql/src/args"
 	"github.com/newrelic/nri-postgresql/src/connection"
-	common_parameters "github.com/newrelic/nri-postgresql/src/query-performance-monitoring/common-parameters"
+	commonparameters "github.com/newrelic/nri-postgresql/src/query-performance-monitoring/common-parameters"
 	"github.com/newrelic/nri-postgresql/src/query-performance-monitoring/datamodels"
 	"github.com/newrelic/nri-postgresql/src/query-performance-monitoring/queries"
 	"github.com/stretchr/testify/assert"
@@ -21,14 +24,14 @@ func TestGetIndividualQueryMetrics(t *testing.T) {
 	version := uint64(13)
 	mockQueryID := "-123"
 	mockQueryText := "SELECT 1"
-	cp := common_parameters.SetCommonParameters(args, version, databaseName)
+	cp := commonparameters.SetCommonParameters(args, version, databaseName)
 
 	// Mock the individual query
 	query := fmt.Sprintf(queries.IndividualQuerySearchV13AndAbove, mockQueryID, databaseName, args.QueryMonitoringResponseTimeThreshold, args.QueryMonitoringCountThreshold)
 	mock.ExpectQuery(regexp.QuoteMeta(query)).WillReturnRows(sqlmock.NewRows([]string{
-		"newrelic", "query", "queryid", "datname", "planid", "cpu_time_ms", "exec_time_ms",
+		"query", "queryid", "datname", "planid", "cpu_time_ms", "exec_time_ms",
 	}).AddRow(
-		"newrelic_value", "SELECT 1", "queryid1", "testdb", "planid1", 10.0, 20.0,
+		"SELECT 1", "queryid1", "testdb", "planid1", 10.0, 20.0,
 	))
 
 	slowRunningQueries := []datamodels.SlowRunningQueryMetrics{
@@ -44,4 +47,68 @@ func TestGetIndividualQueryMetrics(t *testing.T) {
 	assert.Len(t, individualQueryMetricsInterface, 1)
 	assert.Len(t, individualQueryMetrics, 1)
 	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestIndividualQueriesInEligibility(t *testing.T) {
+	conn, mock := connection.CreateMockSQL(t)
+	argumentList := args.ArgumentList{QueryMonitoringCountThreshold: 10}
+	databaseName := "testdb"
+	version := uint64(13)
+	cp := commonparameters.SetCommonParameters(argumentList, version, databaseName)
+	queryText := "SELECT 1"
+	queryID := "123"
+	slowRunningQueries := []datamodels.SlowRunningQueryMetrics{
+		{
+			QueryID:      &queryID,
+			QueryText:    &queryText,
+			DatabaseName: &databaseName,
+		},
+	}
+	enabledExtensions := map[string]bool{"pg_stat_monitor": false}
+	individualQueriesList := PopulateIndividualQueryMetrics(conn, slowRunningQueries, nil, cp, enabledExtensions)
+	assert.Len(t, individualQueriesList, 0)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPopulateIndividualQueryMetrics(t *testing.T) {
+	conn, mock := connection.CreateMockSQL(t)
+	pgIntegration, _ := integration.New("test", "1.0.0")
+	args := args.ArgumentList{QueryMonitoringCountThreshold: 10}
+	enabledExtensions := map[string]bool{"pg_stat_monitor": true}
+	databaseName := "testdb"
+	version := uint64(13)
+	queryText := "SELECT 1"
+	queryID := "123"
+	expectedQuery := queries.IndividualQuerySearchV13AndAbove
+	query := fmt.Sprintf(expectedQuery, "123", databaseName, args.QueryMonitoringResponseTimeThreshold, args.QueryMonitoringCountThreshold)
+	rowData := []driver.Value{
+		"SELECT 1", "queryid1", "testdb", 10.0, 20.0,
+	}
+	mock.ExpectQuery(regexp.QuoteMeta(query)).WillReturnRows(sqlmock.NewRows([]string{
+		"query", "queryid", "datname", "cpu_time_ms", "exec_time_ms",
+	}).AddRow(rowData...).AddRow(rowData...))
+	slowRunningQueries := []datamodels.SlowRunningQueryMetrics{
+		{
+			QueryID:      &queryID,
+			QueryText:    &queryText,
+			DatabaseName: &databaseName,
+		},
+	}
+	cp := commonparameters.SetCommonParameters(args, version, databaseName)
+	individualQueriesList := PopulateIndividualQueryMetrics(conn, slowRunningQueries, pgIntegration, cp, enabledExtensions)
+	expectedRows := [][]driver.Value{
+		rowData, rowData,
+	}
+	compareMockRowsWithIndividualQueryMetrics(t, expectedRows, individualQueriesList)
+	assert.Len(t, individualQueriesList, 2)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func compareMockRowsWithIndividualQueryMetrics(t *testing.T, expectedRows [][]driver.Value, individualQueryMetricsList []datamodels.IndividualQueryInfo) {
+	for index := range individualQueryMetricsList {
+		metric := individualQueryMetricsList[index]
+		assert.Equal(t, expectedRows[index][0], *metric.RealQueryText)
+		assert.Equal(t, expectedRows[index][1], *metric.QueryID)
+		assert.Equal(t, expectedRows[index][2], *metric.DatabaseName)
+	}
 }

--- a/src/query-performance-monitoring/performance-metrics/metrics_collector.go
+++ b/src/query-performance-monitoring/performance-metrics/metrics_collector.go
@@ -1,0 +1,30 @@
+package performancemetrics
+
+import (
+	"github.com/newrelic/infra-integrations-sdk/v3/log"
+	performancedbconnection "github.com/newrelic/nri-postgresql/src/connection"
+)
+
+func fetchMetrics[T any](conn *performancedbconnection.PGSQLConnection, query string, logPrefix string) ([]T, []interface{}, error) {
+	var metricsList []T
+	var metricsListInterface []interface{}
+
+	log.Debug("Executing query to fetch %s metrics", logPrefix)
+	rows, err := conn.Queryx(query)
+	if err != nil {
+		log.Error("Error executing query for %s, error: %v", logPrefix, err)
+		return metricsList, metricsListInterface, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var metric T
+		if scanErr := rows.StructScan(&metric); scanErr != nil {
+			log.Error("Error scanning row into %s: %v", logPrefix, scanErr)
+			return metricsList, metricsListInterface, scanErr
+		}
+		metricsList = append(metricsList, metric)
+		metricsListInterface = append(metricsListInterface, metric)
+	}
+	log.Debug("Fetched %d %s metrics", len(metricsList), logPrefix)
+	return metricsList, metricsListInterface, nil
+}

--- a/src/query-performance-monitoring/performance-metrics/metrics_collector.go
+++ b/src/query-performance-monitoring/performance-metrics/metrics_collector.go
@@ -11,11 +11,11 @@ func fetchMetrics[T any](conn *performancedbconnection.PGSQLConnection, query st
 
 	log.Debug("Executing query to fetch %s metrics", logPrefix)
 	rows, err := conn.Queryx(query)
+	defer rows.Close()
 	if err != nil {
 		log.Error("Error executing query for %s, error: %v", logPrefix, err)
 		return metricsList, metricsListInterface, err
 	}
-	defer rows.Close()
 	for rows.Next() {
 		var metric T
 		if scanErr := rows.StructScan(&metric); scanErr != nil {

--- a/src/query-performance-monitoring/performance-metrics/metrics_collector.go
+++ b/src/query-performance-monitoring/performance-metrics/metrics_collector.go
@@ -11,11 +11,11 @@ func fetchMetrics[T any](conn *performancedbconnection.PGSQLConnection, query st
 
 	log.Debug("Executing query to fetch %s metrics", logPrefix)
 	rows, err := conn.Queryx(query)
-	defer rows.Close()
 	if err != nil {
 		log.Error("Error executing query for %s, error: %v", logPrefix, err)
 		return metricsList, metricsListInterface, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		var metric T
 		if scanErr := rows.StructScan(&metric); scanErr != nil {

--- a/src/query-performance-monitoring/performance-metrics/slow_query_metrics.go
+++ b/src/query-performance-monitoring/performance-metrics/slow_query_metrics.go
@@ -2,7 +2,6 @@ package performancemetrics
 
 import (
 	"fmt"
-
 	"github.com/newrelic/infra-integrations-sdk/v3/integration"
 	"github.com/newrelic/infra-integrations-sdk/v3/log"
 	performancedbconnection "github.com/newrelic/nri-postgresql/src/connection"
@@ -13,55 +12,42 @@ import (
 )
 
 func getSlowRunningMetrics(conn *performancedbconnection.PGSQLConnection, cp *commonparameters.CommonParameters) ([]datamodels.SlowRunningQueryMetrics, []interface{}, error) {
-	var slowQueryMetricsList []datamodels.SlowRunningQueryMetrics
-	var slowQueryMetricsListInterface []interface{}
 	versionSpecificSlowQuery, err := commonutils.FetchVersionSpecificSlowQueries(cp.Version)
 	if err != nil {
 		log.Error("Unsupported postgres version: %v", err)
 		return nil, nil, err
 	}
-	var query = fmt.Sprintf(versionSpecificSlowQuery, cp.Databases, cp.QueryMonitoringCountThreshold)
-	rows, err := conn.Queryx(query)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var slowQuery datamodels.SlowRunningQueryMetrics
-		if scanErr := rows.StructScan(&slowQuery); scanErr != nil {
-			return nil, nil, err
-		}
-		slowQueryMetricsList = append(slowQueryMetricsList, slowQuery)
-		slowQueryMetricsListInterface = append(slowQueryMetricsListInterface, slowQuery)
-	}
-	return slowQueryMetricsList, slowQueryMetricsListInterface, nil
+	query := fmt.Sprintf(versionSpecificSlowQuery, cp.Databases, cp.QueryMonitoringCountThreshold)
+	slowQueryMetricsList, slowQueryMetricsListInterface, err := fetchMetrics[datamodels.SlowRunningQueryMetrics](conn, query, "Slow Running")
+	return slowQueryMetricsList, slowQueryMetricsListInterface, err
 }
 
 func PopulateSlowRunningMetrics(conn *performancedbconnection.PGSQLConnection, pgIntegration *integration.Integration, cp *commonparameters.CommonParameters, enabledExtensions map[string]bool) []datamodels.SlowRunningQueryMetrics {
 	isEligible, err := validations.CheckSlowQueryMetricsFetchEligibility(enabledExtensions)
 	if err != nil {
-		log.Error("Error executing query: %v", err)
-		return nil
+		log.Error("Error executing query for eligibility check: %v", err)
+		return []datamodels.SlowRunningQueryMetrics{}
 	}
 	if !isEligible {
 		log.Debug("Extension 'pg_stat_statements' is not enabled or unsupported version.")
-		return nil
+		return []datamodels.SlowRunningQueryMetrics{}
 	}
 
 	slowQueryMetricsList, slowQueryMetricsListInterface, err := getSlowRunningMetrics(conn, cp)
 	if err != nil {
 		log.Error("Error fetching slow-running queries: %v", err)
-		return nil
+		return []datamodels.SlowRunningQueryMetrics{}
 	}
 
 	if len(slowQueryMetricsList) == 0 {
 		log.Debug("No slow-running queries found.")
-		return nil
+		return []datamodels.SlowRunningQueryMetrics{}
 	}
 	err = commonutils.IngestMetric(slowQueryMetricsListInterface, "PostgresSlowQueries", pgIntegration, cp)
 	if err != nil {
 		log.Error("Error ingesting slow-running queries: %v", err)
-		return nil
+		return []datamodels.SlowRunningQueryMetrics{}
 	}
+	log.Debug("Successfully ingested slow running metrics for databases")
 	return slowQueryMetricsList
 }

--- a/src/query-performance-monitoring/performance-metrics/slow_query_metrics_test.go
+++ b/src/query-performance-monitoring/performance-metrics/slow_query_metrics_test.go
@@ -1,13 +1,17 @@
 package performancemetrics
 
 import (
+	"database/sql/driver"
 	"fmt"
 	"regexp"
 	"testing"
 
+	"github.com/newrelic/infra-integrations-sdk/v3/integration"
+	"github.com/newrelic/nri-postgresql/src/query-performance-monitoring/datamodels"
+
 	"github.com/newrelic/nri-postgresql/src/args"
 	"github.com/newrelic/nri-postgresql/src/connection"
-	common_parameters "github.com/newrelic/nri-postgresql/src/query-performance-monitoring/common-parameters"
+	commonparameters "github.com/newrelic/nri-postgresql/src/query-performance-monitoring/common-parameters"
 	commonutils "github.com/newrelic/nri-postgresql/src/query-performance-monitoring/common-utils"
 	"github.com/newrelic/nri-postgresql/src/query-performance-monitoring/queries"
 	"github.com/stretchr/testify/assert"
@@ -18,14 +22,14 @@ func runSlowQueryTest(t *testing.T, query string, version uint64, expectedLength
 	conn, mock := connection.CreateMockSQL(t)
 	args := args.ArgumentList{QueryMonitoringCountThreshold: 10}
 	databaseName := "testdb"
-	cp := common_parameters.SetCommonParameters(args, version, databaseName)
+	cp := commonparameters.SetCommonParameters(args, version, databaseName)
 
 	query = fmt.Sprintf(query, "testdb", args.QueryMonitoringCountThreshold)
 	mock.ExpectQuery(regexp.QuoteMeta(query)).WillReturnRows(sqlmock.NewRows([]string{
-		"newrelic", "query_id", "query_text", "database_name", "schema_name", "execution_count",
+		"query_id", "query_text", "database_name", "schema_name", "execution_count",
 		"avg_elapsed_time_ms", "avg_disk_reads", "avg_disk_writes", "statement_type", "collection_timestamp",
 	}).AddRow(
-		"newrelic_value", "queryid1", "SELECT 1", "testdb", "public", 10,
+		"queryid1", "SELECT 1", "testdb", "public", 10,
 		15.0, 5, 2, "SELECT", "2023-01-01T00:00:00Z",
 	))
 	slowQueryList, _, err := getSlowRunningMetrics(conn, cp)
@@ -47,11 +51,11 @@ func TestGetSlowRunningEmptyMetrics(t *testing.T) {
 	args := args.ArgumentList{QueryMonitoringCountThreshold: 10}
 	databaseName := "testdb"
 	version := uint64(13)
-	cp := common_parameters.SetCommonParameters(args, version, databaseName)
+	cp := commonparameters.SetCommonParameters(args, version, databaseName)
 	expectedQuery := queries.SlowQueriesForV13AndAbove
 	query := fmt.Sprintf(expectedQuery, "testdb", args.QueryMonitoringCountThreshold)
 	mock.ExpectQuery(regexp.QuoteMeta(query)).WillReturnRows(sqlmock.NewRows([]string{
-		"newrelic", "query_id", "query_text", "database_name", "schema_name", "execution_count",
+		"query_id", "query_text", "database_name", "schema_name", "execution_count",
 		"avg_elapsed_time_ms", "avg_disk_reads", "avg_disk_writes", "statement_type", "collection_timestamp",
 	}))
 	slowQueryList, _, err := getSlowRunningMetrics(conn, cp)
@@ -66,9 +70,59 @@ func TestGetSlowRunningMetricsUnsupportedVersion(t *testing.T) {
 	args := args.ArgumentList{QueryMonitoringCountThreshold: 10}
 	databaseName := "testdb"
 	version := uint64(11)
-	cp := common_parameters.SetCommonParameters(args, version, databaseName)
+	cp := commonparameters.SetCommonParameters(args, version, databaseName)
 	slowQueryList, _, err := getSlowRunningMetrics(conn, cp)
 	assert.EqualError(t, err, commonutils.ErrUnsupportedVersion.Error())
 	assert.Len(t, slowQueryList, 0)
 	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestInEligibility(t *testing.T) {
+	conn, _ := connection.CreateMockSQL(t)
+	argumentList := args.ArgumentList{QueryMonitoringCountThreshold: 10}
+	enabledExtensions := map[string]bool{"pg_stat_statements": false}
+	cp := commonparameters.SetCommonParameters(argumentList, 13, "testdb")
+	slowQueryMetricsList := PopulateSlowRunningMetrics(conn, nil, cp, enabledExtensions)
+	assert.Len(t, slowQueryMetricsList, 0)
+}
+
+func TestPopulateSlowRunningMetrics(t *testing.T) {
+	conn, mock := connection.CreateMockSQL(t)
+	pgIntegration, _ := integration.New("test", "1.0.0")
+	argumentList := args.ArgumentList{QueryMonitoringCountThreshold: 10, Hostname: "localhost", Port: "5432"}
+	databaseName := "testdb"
+	cp := commonparameters.SetCommonParameters(argumentList, 13, databaseName)
+	enabledExtensions := map[string]bool{"pg_stat_statements": true}
+	query := fmt.Sprintf(queries.SlowQueriesForV13AndAbove, "testdb", argumentList.QueryMonitoringCountThreshold)
+	rowData := []driver.Value{
+		"queryid1", "SELECT ?", "testdb", "public", int64(10),
+		float64(15), float64(5), float64(2), "SELECT", "2023-01-01T00:00:00Z",
+	}
+	mock.ExpectQuery(regexp.QuoteMeta(query)).WillReturnRows(sqlmock.NewRows([]string{
+		"query_id", "query_text", "database_name", "schema_name", "execution_count",
+		"avg_elapsed_time_ms", "avg_disk_reads", "avg_disk_writes", "statement_type", "collection_timestamp",
+	}).AddRow(rowData...).AddRow(rowData...))
+	expectedRows := [][]driver.Value{
+		rowData, rowData,
+	}
+	slowQueryMetricsList := PopulateSlowRunningMetrics(conn, pgIntegration, cp, enabledExtensions)
+	compareMockRowsWithSlowQueryMetrics(t, expectedRows, slowQueryMetricsList)
+	assert.Len(t, slowQueryMetricsList, 2)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func compareMockRowsWithSlowQueryMetrics(t *testing.T, expectedRows [][]driver.Value, slowQueryMetricList []datamodels.SlowRunningQueryMetrics) {
+	for index := range slowQueryMetricList {
+		metric := slowQueryMetricList[index]
+		assert.Equal(t, expectedRows[index][0], *metric.QueryID)
+		assert.Equal(t, expectedRows[index][1], *metric.QueryText)
+		assert.Equal(t, expectedRows[index][2], *metric.DatabaseName)
+		assert.Equal(t, expectedRows[index][3], *metric.SchemaName)
+		assert.Equal(t, expectedRows[index][4], *metric.ExecutionCount)
+		assert.Equal(t, expectedRows[index][5], *metric.AvgElapsedTimeMs)
+		assert.Equal(t, expectedRows[index][6], *metric.AvgDiskReads)
+		assert.Equal(t, expectedRows[index][7], *metric.AvgDiskWrites)
+		assert.Equal(t, expectedRows[index][8], *metric.StatementType)
+		assert.Equal(t, expectedRows[index][9], *metric.CollectionTimestamp)
+	}
 }

--- a/src/query-performance-monitoring/performance-metrics/wait_event_metrics.go
+++ b/src/query-performance-monitoring/performance-metrics/wait_event_metrics.go
@@ -18,7 +18,7 @@ func PopulateWaitEventMetrics(conn *performancedbconnection.PGSQLConnection, pgI
 	var eligibleCheckErr error
 	isEligible, eligibleCheckErr = validations.CheckWaitEventMetricsFetchEligibility(enabledExtensions)
 	if eligibleCheckErr != nil {
-		log.Error("Error executing query: %v", eligibleCheckErr)
+		log.Error("Error executing query for eligibility check: %v", eligibleCheckErr)
 		return commonutils.ErrUnExpectedError
 	}
 	if !isEligible {
@@ -39,23 +39,12 @@ func PopulateWaitEventMetrics(conn *performancedbconnection.PGSQLConnection, pgI
 		log.Error("Error ingesting wait event queries: %v", err)
 		return err
 	}
+	log.Debug("Successfully ingested wait event metrics for databases")
 	return nil
 }
 
 func getWaitEventMetrics(conn *performancedbconnection.PGSQLConnection, cp *commonparameters.CommonParameters) ([]interface{}, error) {
-	var waitEventMetricsList []interface{}
-	var query = fmt.Sprintf(queries.WaitEvents, cp.Databases, cp.QueryMonitoringCountThreshold)
-	rows, err := conn.Queryx(query)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var waitEvent datamodels.WaitEventMetrics
-		if waitScanErr := rows.StructScan(&waitEvent); waitScanErr != nil {
-			return nil, err
-		}
-		waitEventMetricsList = append(waitEventMetricsList, waitEvent)
-	}
-	return waitEventMetricsList, nil
+	query := fmt.Sprintf(queries.WaitEvents, cp.Databases, cp.QueryMonitoringCountThreshold)
+	_, waitEventMetricsListInterface, err := fetchMetrics[datamodels.WaitEventMetrics](conn, query, "Wait Event")
+	return waitEventMetricsListInterface, err
 }

--- a/src/query-performance-monitoring/performance-metrics/wait_event_metrics_test.go
+++ b/src/query-performance-monitoring/performance-metrics/wait_event_metrics_test.go
@@ -1,13 +1,17 @@
 package performancemetrics
 
 import (
+	"database/sql/driver"
 	"fmt"
 	"regexp"
 	"testing"
 
+	"github.com/newrelic/infra-integrations-sdk/v3/integration"
+	commonutils "github.com/newrelic/nri-postgresql/src/query-performance-monitoring/common-utils"
+
 	"github.com/newrelic/nri-postgresql/src/args"
 	"github.com/newrelic/nri-postgresql/src/connection"
-	common_parameters "github.com/newrelic/nri-postgresql/src/query-performance-monitoring/common-parameters"
+	commonparameters "github.com/newrelic/nri-postgresql/src/query-performance-monitoring/common-parameters"
 	"github.com/newrelic/nri-postgresql/src/query-performance-monitoring/queries"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
@@ -17,7 +21,7 @@ func TestGetWaitEventMetrics(t *testing.T) {
 	conn, mock := connection.CreateMockSQL(t)
 	args := args.ArgumentList{QueryMonitoringCountThreshold: 10}
 	databaseName := "testdb"
-	cp := common_parameters.SetCommonParameters(args, uint64(14), databaseName)
+	cp := commonparameters.SetCommonParameters(args, uint64(14), databaseName)
 
 	var query = fmt.Sprintf(queries.WaitEvents, databaseName, args.QueryMonitoringCountThreshold)
 	mock.ExpectQuery(regexp.QuoteMeta(query)).WillReturnRows(sqlmock.NewRows([]string{
@@ -36,7 +40,7 @@ func TestGetWaitEventEmptyMetrics(t *testing.T) {
 	conn, mock := connection.CreateMockSQL(t)
 	args := args.ArgumentList{QueryMonitoringCountThreshold: 10}
 	databaseName := "testdb"
-	cp := common_parameters.SetCommonParameters(args, uint64(14), databaseName)
+	cp := commonparameters.SetCommonParameters(args, uint64(14), databaseName)
 
 	var query = fmt.Sprintf(queries.WaitEvents, databaseName, args.QueryMonitoringCountThreshold)
 	mock.ExpectQuery(regexp.QuoteMeta(query)).WillReturnRows(sqlmock.NewRows([]string{
@@ -45,5 +49,48 @@ func TestGetWaitEventEmptyMetrics(t *testing.T) {
 	waitEventsList, err := getWaitEventMetrics(conn, cp)
 	assert.NoError(t, err)
 	assert.Len(t, waitEventsList, 0)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestInEligibilityWaitEvents(t *testing.T) {
+	conn, mock := connection.CreateMockSQL(t)
+	pgIntegration, _ := integration.New("test", "1.0.0")
+	argumentList := args.ArgumentList{QueryMonitoringCountThreshold: 10, Hostname: "localhost", Port: "5432"}
+	databaseName := "testdb"
+	cp := commonparameters.SetCommonParameters(argumentList, 14, databaseName)
+	enabledExtensions := map[string]bool{"pg_wait_sampling": false}
+	err := PopulateWaitEventMetrics(conn, pgIntegration, cp, enabledExtensions)
+	assert.Equal(t, err, commonutils.ErrNotEligible)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPopulateWaitEventMetricsErr(t *testing.T) {
+	conn, mock := connection.CreateMockSQL(t)
+	pgIntegration, _ := integration.New("test", "1.0.0")
+	argumentList := args.ArgumentList{QueryMonitoringCountThreshold: 10, Hostname: "localhost", Port: "5432"}
+	databaseName := "testdb"
+	cp := commonparameters.SetCommonParameters(argumentList, 14, databaseName)
+	enabledExtensions := map[string]bool{"pg_wait_sampling": true, "pg_stat_statements": true}
+	err := PopulateWaitEventMetrics(conn, pgIntegration, cp, enabledExtensions)
+	assert.Equal(t, err, commonutils.ErrUnExpectedError)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPopulateWaitEventMetrics(t *testing.T) {
+	conn, mock := connection.CreateMockSQL(t)
+	pgIntegration, _ := integration.New("test", "1.0.0")
+	argumentList := args.ArgumentList{QueryMonitoringCountThreshold: 10, Hostname: "localhost", Port: "5432"}
+	databaseName := "testdb"
+	cp := commonparameters.SetCommonParameters(argumentList, 14, databaseName)
+	enabledExtensions := map[string]bool{"pg_wait_sampling": true, "pg_stat_statements": true}
+	query := fmt.Sprintf(queries.WaitEvents, databaseName, argumentList.QueryMonitoringCountThreshold)
+	rowData := []driver.Value{
+		"Locks:Lock", "Locks", 1000.0, "2023-01-01T00:00:00Z", "queryid1", "SELECT 1", "testdb",
+	}
+	mock.ExpectQuery(regexp.QuoteMeta(query)).WillReturnRows(sqlmock.NewRows([]string{
+		"wait_event_name", "wait_category", "total_wait_time_ms", "collection_timestamp", "query_id", "query_text", "database_name",
+	}).AddRow(rowData...).AddRow(rowData...))
+	err := PopulateWaitEventMetrics(conn, pgIntegration, cp, enabledExtensions)
+	assert.NoError(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/src/query-performance-monitoring/queries/queries.go
+++ b/src/query-performance-monitoring/queries/queries.go
@@ -2,7 +2,7 @@
 package queries
 
 const (
-	SlowQueriesForV13AndAbove = `SELECT 'newrelic' as newrelic, -- Common value to filter with like operator in slow query metrics
+	SlowQueriesForV13AndAbove = `SELECT
 		pss.queryid AS query_id, -- Unique identifier for the query
 		LEFT(pss.query, 4095) AS query_text, -- Query text truncated to 4095 characters
 		pd.datname AS database_name, -- Name of the database
@@ -25,19 +25,12 @@ const (
 		pg_database pd ON pss.dbid = pd.oid
 	WHERE 
 		pd.datname in (%s) -- List of database names
-		AND pss.query NOT ILIKE 'EXPLAIN (FORMAT JSON)%%' -- Exclude EXPLAIN queries
-		AND pss.query NOT ILIKE 'SELECT $1 as newrelic%%' -- Exclude specific New Relic queries
-		AND pss.query NOT ILIKE 'WITH wait_history AS%%' -- Exclude specific WITH queries
-		AND pss.query NOT ILIKE 'select -- BLOATQUERY%%' -- Exclude BLOATQUERY
-		AND pss.query NOT ILIKE 'select -- INDEXQUERY%%' -- Exclude INDEXQUERY
-		AND pss.query NOT ILIKE 'SELECT -- TABLEQUERY%%' -- Exclude TABLEQUERY
-		AND pss.query NOT ILIKE 'SELECT table_schema%%' -- Exclude table_schema queries
 	ORDER BY
 		avg_elapsed_time_ms DESC -- Order by the average elapsed time in descending order
 	LIMIT %d;`
 
 	// SlowQueriesForV12 retrieves slow queries and their statistics for PostgreSQL version 12
-	SlowQueriesForV12 = `SELECT 'newrelic' as newrelic, -- Common value to filter with like operator in slow query metrics
+	SlowQueriesForV12 = `SELECT
 		pss.queryid AS query_id, -- Unique identifier for the query
 		LEFT(pss.query, 4095) AS query_text, -- Query text truncated to 4095 characters
 		pd.datname AS database_name, -- Name of the database
@@ -60,14 +53,6 @@ const (
 		pg_database pd ON pss.dbid = pd.oid
 		WHERE 
 		pd.datname in (%s) -- List of database names
-		AND pss.query NOT ILIKE 'EXPLAIN (FORMAT JSON) %%' -- Exclude EXPLAIN queries
-		AND pss.query NOT ILIKE 'SELECT $1 as newrelic%%' -- Exclude specific New Relic queries
-		AND pss.query NOT ILIKE 'WITH wait_history AS%%' -- Exclude specific WITH queries
-		AND pss.query NOT ILIKE 'select -- BLOATQUERY%%' -- Exclude BLOATQUERY
-		AND pss.query NOT ILIKE 'select -- INDEXQUERY%%' -- Exclude INDEXQUERY
-		AND pss.query NOT ILIKE 'SELECT -- TABLEQUERY%%' -- Exclude TABLEQUERY
-		AND pss.query NOT ILIKE 'SELECT table_schema%%' -- Exclude table_schema queries
-		AND pss.query NOT ILIKE 'SELECT D.datname%%' -- Exclude specific datname queries
 	ORDER BY
 		avg_elapsed_time_ms DESC -- Order by the average elapsed time in descending order
 	LIMIT
@@ -112,7 +97,7 @@ const (
 	LIMIT %d; -- Limit the number of results`
 
 	// BlockingQueriesForV14AndAbove retrieves information about blocking and blocked queries for PostgreSQL version 14 and above
-	BlockingQueriesForV14AndAbove = `SELECT 'newrelic' as newrelic, -- Common value to filter with like operator in slow query metrics
+	BlockingQueriesForV14AndAbove = `SELECT
 		  blocked_activity.pid AS blocked_pid, -- Process ID of the blocked query
 		  LEFT(blocked_statements.query, 4095) AS blocked_query, -- Blocked query text truncated to 4095 characters
 		  blocked_statements.queryid AS blocked_query_id, -- Unique identifier for the blocked query
@@ -145,7 +130,7 @@ const (
 		LIMIT %d; -- Limit the number of results`
 
 	// BlockingQueriesForV12AndV13 retrieves information about blocking and blocked queries for PostgreSQL versions 12 and 13
-	BlockingQueriesForV12AndV13 = `SELECT 'newrelic' as newrelic, -- Common value to filter with like operator in slow query metrics
+	BlockingQueriesForV12AndV13 = `SELECT
 		blocked_activity.pid AS blocked_pid, -- Process ID of the blocked query
 		LEFT(blocked_activity.query, 4095) AS blocked_query, -- Blocked query text truncated to 4095 characters
 		blocked_activity.query_start AS blocked_query_start, -- Start time of the blocked query
@@ -174,7 +159,7 @@ const (
 		LIMIT %d; -- Limit the number of results`
 
 	// IndividualQuerySearchV13AndAbove retrieves individual query statistics for PostgreSQL version 13 and above
-	IndividualQuerySearchV13AndAbove = `SELECT 'newrelic' as newrelic, -- Common value to filter with like operator in slow query metrics
+	IndividualQuerySearchV13AndAbove = `SELECT 
 		 LEFT(query, 4095) as query, -- Query text truncated to 4095 characters
 		 queryid, -- Unique identifier for the query
 		 datname, -- Name of the database
@@ -195,7 +180,7 @@ const (
 		LIMIT %d; -- Limit the number of results`
 
 	// IndividualQuerySearchV12 retrieves individual query statistics for PostgreSQL version 12
-	IndividualQuerySearchV12 = `SELECT 'newrelic' as newrelic, -- Common value to filter with like operator in slow query metrics
+	IndividualQuerySearchV12 = `SELECT
 		 LEFT(query, 4095) as query, -- Query text truncated to 4095 characters
 		 queryid, -- Unique identifier for the query
 		 datname, -- Name of the database


### PR DESCRIPTION
1. Removed System queries and OHI queries filter
2. Added more unit test cases
3. Added QueryMonitoringOnly flag to enable only query monitoring feature
4. usage of marshal metrics
5. common function which is reused to fetch metrics 
6. return parameter which were expected datatype instead of nil