### PR TITLE
feat: Added query performance monitoring support for Aurora/RDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 ## Unreleased
 ### enhancements
 - Add Query Level Monitoring support for RDS Postgres
-- Add QueryMonitoringOnly flag to collect only query level monitoring metrics
 
 ## v2.17.1 - 2025-02-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Unreleased section should follow [Release Toolkit](https://github.com/newrelic/release-toolkit#render-markdown-and-update-markdown)
 
 ## Unreleased
+### enhancements
+- Add Query Level Monitoring support for RDS Postgres
+- Add QueryMonitoringOnly flag to collect only query level monitoring metrics
 
 ## v2.17.1 - 2025-02-19
 

--- a/postgresql-config.yml.sample
+++ b/postgresql-config.yml.sample
@@ -49,7 +49,10 @@ integrations:
     
     # True if SSL is to be used. Defaults to false.
     ENABLE_SSL: "false"
-
+    
+    # Enable collection of only detailed query performance metrics, excluding other metrics. - Defaults to false
+    QUERY_MONITORING_ONLY : "false"
+    
     # Enable query performance monitoring - Defaults to false
     # ENABLE_QUERY_MONITORING : "false"
 

--- a/postgresql-config.yml.sample
+++ b/postgresql-config.yml.sample
@@ -52,6 +52,9 @@ integrations:
     
     # Enable collection of only detailed query performance metrics, excluding other metrics. - Defaults to false
     QUERY_MONITORING_ONLY : "false"
+
+    # Enable query performance monitoring for Aurora/RDS - Defaults to false
+    IS_RDS: "false"
     
     # Enable query performance monitoring - Defaults to false
     # ENABLE_QUERY_MONITORING : "false"

--- a/postgresql-config.yml.sample
+++ b/postgresql-config.yml.sample
@@ -50,9 +50,6 @@ integrations:
     # True if SSL is to be used. Defaults to false.
     ENABLE_SSL: "false"
     
-    # Enable collection of only detailed query performance metrics, excluding other metrics. - Defaults to false
-    QUERY_MONITORING_ONLY : "false"
-
     # Enable query performance monitoring for Aurora/RDS - Defaults to false
     IS_RDS: "false"
     

--- a/src/args/argument_list.go
+++ b/src/args/argument_list.go
@@ -31,7 +31,6 @@ type ArgumentList struct {
 	CollectBloatMetrics                  bool   `default:"true" help:"Enable collecting bloat metrics which can be performance intensive"`
 	ShowVersion                          bool   `default:"false" help:"Print build information and exit"`
 	EnableQueryMonitoring                bool   `default:"false" help:"Enable collection of detailed query performance metrics."`
-	QueryMonitoringOnly                  bool   `default:"false" help:"Enable collection of only detailed query performance metrics, excluding other metrics."`
 	QueryMonitoringResponseTimeThreshold int    `default:"500" help:"Threshold in milliseconds for query response time. If response time for the individual query exceeds this threshold, the individual query is reported in metrics"`
 	QueryMonitoringCountThreshold        int    `default:"20" help:"The number of records for each query performance metrics"`
 	IsRds                                bool   `default:"false" help:"If true, the integration will support on AWS RDS. This will enable RDS-specific metrics and configurations."`

--- a/src/args/argument_list.go
+++ b/src/args/argument_list.go
@@ -34,6 +34,7 @@ type ArgumentList struct {
 	QueryMonitoringOnly                  bool   `default:"false" help:"Enable collection of only detailed query performance metrics, excluding other metrics."`
 	QueryMonitoringResponseTimeThreshold int    `default:"500" help:"Threshold in milliseconds for query response time. If response time for the individual query exceeds this threshold, the individual query is reported in metrics"`
 	QueryMonitoringCountThreshold        int    `default:"20" help:"The number of records for each query performance metrics"`
+	IsRds                                bool   `default:"false" help:"If true, the integration will support on AWS RDS. This will enable RDS-specific metrics and configurations."`
 }
 
 // Validate validates PostgreSQl arguments

--- a/src/args/argument_list.go
+++ b/src/args/argument_list.go
@@ -31,6 +31,7 @@ type ArgumentList struct {
 	CollectBloatMetrics                  bool   `default:"true" help:"Enable collecting bloat metrics which can be performance intensive"`
 	ShowVersion                          bool   `default:"false" help:"Print build information and exit"`
 	EnableQueryMonitoring                bool   `default:"false" help:"Enable collection of detailed query performance metrics."`
+	QueryMonitoringOnly                  bool   `default:"false" help:"Enable collection of only detailed query performance metrics, excluding other metrics."`
 	QueryMonitoringResponseTimeThreshold int    `default:"500" help:"Threshold in milliseconds for query response time. If response time for the individual query exceeds this threshold, the individual query is reported in metrics"`
 	QueryMonitoringCountThreshold        int    `default:"20" help:"The number of records for each query performance metrics"`
 }

--- a/src/main.go
+++ b/src/main.go
@@ -70,10 +70,6 @@ func main() {
 		log.Error("Error creating instance entity: %s", err.Error())
 		os.Exit(1)
 	}
-	if args.QueryMonitoringOnly {
-		queryperformancemonitoring.QueryPerformanceMain(args, pgIntegration, collectionList)
-		return
-	}
 	if args.HasMetrics() {
 		metrics.PopulateMetrics(connectionInfo, collectionList, instance, pgIntegration, args.Pgbouncer, args.CollectDbLockMetrics, args.CollectBloatMetrics, args.CustomMetricsQuery)
 		if args.CustomMetricsConfig != "" {

--- a/src/main.go
+++ b/src/main.go
@@ -70,7 +70,10 @@ func main() {
 		log.Error("Error creating instance entity: %s", err.Error())
 		os.Exit(1)
 	}
-
+	if args.QueryMonitoringOnly {
+		queryperformancemonitoring.QueryPerformanceMain(args, pgIntegration, collectionList)
+		return
+	}
 	if args.HasMetrics() {
 		metrics.PopulateMetrics(connectionInfo, collectionList, instance, pgIntegration, args.Pgbouncer, args.CollectDbLockMetrics, args.CollectBloatMetrics, args.CustomMetricsQuery)
 		if args.CustomMetricsConfig != "" {

--- a/src/query-performance-monitoring/common-parameters/common_parameters.go
+++ b/src/query-performance-monitoring/common-parameters/common_parameters.go
@@ -1,6 +1,8 @@
 package commonparameters
 
 import (
+	"strings"
+
 	"github.com/newrelic/infra-integrations-sdk/v3/log"
 	"github.com/newrelic/nri-postgresql/src/args"
 )
@@ -21,6 +23,7 @@ type CommonParameters struct {
 	QueryMonitoringResponseTimeThreshold int
 	Host                                 string
 	Port                                 string
+	IsRds                                bool
 }
 
 func SetCommonParameters(args args.ArgumentList, version uint64, databases string) *CommonParameters {
@@ -31,7 +34,12 @@ func SetCommonParameters(args args.ArgumentList, version uint64, databases strin
 		QueryMonitoringResponseTimeThreshold: validateAndGetQueryMonitoringResponseTimeThreshold(args),
 		Host:                                 args.Hostname,
 		Port:                                 args.Port,
+		IsRds:                                isRdsHost(args.Hostname),
 	}
+}
+
+func isRdsHost(hostname string) bool {
+	return strings.Contains(hostname, ".rds.amazonaws.com")
 }
 
 func validateAndGetQueryMonitoringResponseTimeThreshold(args args.ArgumentList) int {

--- a/src/query-performance-monitoring/common-parameters/common_parameters.go
+++ b/src/query-performance-monitoring/common-parameters/common_parameters.go
@@ -38,6 +38,7 @@ func SetCommonParameters(args args.ArgumentList, version uint64, databases strin
 	}
 }
 
+// A reliable way to identify hostnames associated with Amazon Relational Database Service (RDS) instances. Amazon uses this domain suffix for RDS endpoints across various database engines.
 func isRdsHost(hostname string) bool {
 	return strings.Contains(hostname, ".rds.amazonaws.com")
 }

--- a/src/query-performance-monitoring/common-parameters/common_parameters.go
+++ b/src/query-performance-monitoring/common-parameters/common_parameters.go
@@ -1,8 +1,6 @@
 package commonparameters
 
 import (
-	"strings"
-
 	"github.com/newrelic/infra-integrations-sdk/v3/log"
 	"github.com/newrelic/nri-postgresql/src/args"
 )
@@ -34,13 +32,8 @@ func SetCommonParameters(args args.ArgumentList, version uint64, databases strin
 		QueryMonitoringResponseTimeThreshold: validateAndGetQueryMonitoringResponseTimeThreshold(args),
 		Host:                                 args.Hostname,
 		Port:                                 args.Port,
-		IsRds:                                isRdsHost(args.Hostname),
+		IsRds:                                args.IsRds,
 	}
-}
-
-// A reliable way to identify hostnames associated with Amazon Relational Database Service (RDS) instances. Amazon uses this domain suffix for RDS endpoints across various database engines.
-func isRdsHost(hostname string) bool {
-	return strings.Contains(hostname, ".rds.amazonaws.com")
 }
 
 func validateAndGetQueryMonitoringResponseTimeThreshold(args args.ArgumentList) int {

--- a/src/query-performance-monitoring/common-utils/common_helpers.go
+++ b/src/query-performance-monitoring/common-utils/common_helpers.go
@@ -40,3 +40,26 @@ func GeneratePlanID() (string, error) {
 	result := fmt.Sprintf("%d-%s", randomInt.Int64(), currentTime)
 	return result, nil
 }
+
+func AnonymizeAndNormalize(query string) string {
+	reNumbers := regexp.MustCompile(`\d+`)
+	cleanedQuery := reNumbers.ReplaceAllString(query, "?")
+
+	reSingleQuotes := regexp.MustCompile(`'[^']*'`)
+	cleanedQuery = reSingleQuotes.ReplaceAllString(cleanedQuery, "?")
+
+	reDoubleQuotes := regexp.MustCompile(`"[^"]*"`)
+	cleanedQuery = reDoubleQuotes.ReplaceAllString(cleanedQuery, "?")
+
+	cleanedQuery = strings.ReplaceAll(cleanedQuery, "$", "")
+
+	cleanedQuery = strings.ToLower(cleanedQuery)
+
+	cleanedQuery = strings.ReplaceAll(cleanedQuery, ";", "")
+
+	cleanedQuery = strings.TrimSpace(cleanedQuery)
+
+	cleanedQuery = strings.Join(strings.Fields(cleanedQuery), " ")
+
+	return cleanedQuery
+}

--- a/src/query-performance-monitoring/common-utils/common_helpers_test.go
+++ b/src/query-performance-monitoring/common-utils/common_helpers_test.go
@@ -36,3 +36,59 @@ func TestAnonymizeQueryText(t *testing.T) {
 	result = AnonymizeQueryText(query)
 	assert.Equal(t, expected, result)
 }
+
+func TestAnonymizeAndNormalize(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Replace numbers with placeholders",
+			input:    "SELECT * FROM users WHERE id = 123",
+			expected: "select * from users where id = ?",
+		},
+		{
+			name:     "Replace single-quoted strings with placeholders",
+			input:    "SELECT * FROM users WHERE name = 'John'",
+			expected: "select * from users where name = ?",
+		},
+		{
+			name:     "Replace double-quoted strings with placeholders",
+			input:    `SELECT * FROM "users" WHERE "name" = "John"`,
+			expected: "select * from ? where ? = ?",
+		},
+		{
+			name:     "Remove dollar signs",
+			input:    "SELECT $1 FROM users WHERE id = $2",
+			expected: "select ? from users where id = ?",
+		},
+		{
+			name:     "Convert to lowercase",
+			input:    "SELECT * FROM USERS",
+			expected: "select * from users",
+		},
+		{
+			name:     "Remove semicolons",
+			input:    "SELECT * FROM users;",
+			expected: "select * from users",
+		},
+		{
+			name:     "Trim and normalize spaces",
+			input:    "  SELECT   *   FROM   users   ",
+			expected: "select * from users",
+		},
+		{
+			name:     "Complex query",
+			input:    "SELECT * FROM employees WHERE id = 10 OR name = 'John Doe';",
+			expected: "select * from employees where id = ? or name = ?",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := AnonymizeAndNormalize(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/src/query-performance-monitoring/common-utils/constants.go
+++ b/src/query-performance-monitoring/common-utils/constants.go
@@ -20,3 +20,6 @@ const PostgresVersion12 = 12
 const PostgresVersion11 = 11
 const PostgresVersion13 = 13
 const PostgresVersion14 = 14
+
+const PgStatStatementExtension = "pg_stat_statements"
+const PgStatMonitorExtension = "pg_stat_monitor"

--- a/src/query-performance-monitoring/common-utils/constants.go
+++ b/src/query-performance-monitoring/common-utils/constants.go
@@ -23,3 +23,4 @@ const PostgresVersion14 = 14
 
 const PgStatStatementExtension = "pg_stat_statements"
 const PgStatMonitorExtension = "pg_stat_monitor"
+const PgWaitSamplingExtension = "pg_wait_sampling"

--- a/src/query-performance-monitoring/common-utils/query_fetch_helpers.go
+++ b/src/query-performance-monitoring/common-utils/query_fetch_helpers.go
@@ -4,7 +4,7 @@ import (
 	"github.com/newrelic/nri-postgresql/src/query-performance-monitoring/queries"
 )
 
-func FetchVersionSpecificSlowQueries(version uint64) (string, error) {
+func FetchVersionSpecificSlowQuery(version uint64) (string, error) {
 	switch {
 	case version == PostgresVersion12:
 		return queries.SlowQueriesForV12, nil
@@ -15,11 +15,13 @@ func FetchVersionSpecificSlowQueries(version uint64) (string, error) {
 	}
 }
 
-func FetchVersionSpecificBlockingQueries(version uint64) (string, error) {
+func FetchVersionSpecificBlockingQuery(version uint64, isRds bool) (string, error) {
 	switch {
 	case version == PostgresVersion12, version == PostgresVersion13:
 		return queries.BlockingQueriesForV12AndV13, nil
-	case version >= PostgresVersion14:
+	case version >= PostgresVersion14 && isRds:
+		return queries.RDSPostgresBlockingQueryForV14AndAbove, nil
+	case version >= PostgresVersion14 && !isRds:
 		return queries.BlockingQueriesForV14AndAbove, nil
 	default:
 		return "", ErrUnsupportedVersion
@@ -34,5 +36,13 @@ func FetchVersionSpecificIndividualQueries(version uint64) (string, error) {
 		return queries.IndividualQuerySearchV13AndAbove, nil
 	default:
 		return "", ErrUnsupportedVersion
+	}
+}
+
+func FetchSupportedWaitEventsQuery(isRDS bool) (string, error) {
+	if isRDS {
+		return queries.WaitEventsFromPgStatActivity, nil
+	} else {
+		return queries.WaitEvents, nil
 	}
 }

--- a/src/query-performance-monitoring/common-utils/query_fetch_helpers.go
+++ b/src/query-performance-monitoring/common-utils/query_fetch_helpers.go
@@ -15,13 +15,11 @@ func FetchVersionSpecificSlowQuery(version uint64) (string, error) {
 	}
 }
 
-func FetchVersionSpecificBlockingQuery(version uint64, isRds bool) (string, error) {
+func FetchVersionSpecificBlockingQuery(version uint64) (string, error) {
 	switch {
 	case version == PostgresVersion12, version == PostgresVersion13:
 		return queries.BlockingQueriesForV12AndV13, nil
-	case version >= PostgresVersion14 && isRds:
-		return queries.RDSPostgresBlockingQueryForV14AndAbove, nil
-	case version >= PostgresVersion14 && !isRds:
+	case version >= PostgresVersion14:
 		return queries.BlockingQueriesForV14AndAbove, nil
 	default:
 		return "", ErrUnsupportedVersion
@@ -36,13 +34,5 @@ func FetchVersionSpecificIndividualQueries(version uint64) (string, error) {
 		return queries.IndividualQuerySearchV13AndAbove, nil
 	default:
 		return "", ErrUnsupportedVersion
-	}
-}
-
-func FetchSupportedWaitEventsQuery(isRDS bool) (string, error) {
-	if isRDS {
-		return queries.WaitEventsFromPgStatActivity, nil
-	} else {
-		return queries.WaitEvents, nil
 	}
 }

--- a/src/query-performance-monitoring/common-utils/query_fetch_helpers_test.go
+++ b/src/query-performance-monitoring/common-utils/query_fetch_helpers_test.go
@@ -43,25 +43,15 @@ func TestFetchVersionSpecificBlockingQueries(t *testing.T) {
 	tests := []struct {
 		version   uint64
 		expected  string
-		isRDS     bool
 		expectErr bool
 	}{
-		{commonutils.PostgresVersion12, queries.BlockingQueriesForV12AndV13, false, false},
-		{commonutils.PostgresVersion13, queries.BlockingQueriesForV12AndV13, false, false},
-		{commonutils.PostgresVersion14, queries.BlockingQueriesForV14AndAbove, false, false},
-		{commonutils.PostgresVersion14, queries.RDSPostgresBlockingQueryForV14AndAbove, true, false},
-		{commonutils.PostgresVersion11, "", false, true},
+		{commonutils.PostgresVersion12, queries.BlockingQueriesForV12AndV13, false},
+		{commonutils.PostgresVersion13, queries.BlockingQueriesForV12AndV13, false},
+		{commonutils.PostgresVersion14, queries.BlockingQueriesForV14AndAbove, false},
+		{commonutils.PostgresVersion11, "", true},
 	}
 
-	for _, test := range tests {
-		result, err := commonutils.FetchVersionSpecificBlockingQuery(test.version, test.isRDS)
-		if test.expectErr {
-			assert.Error(t, err)
-		} else {
-			assert.NoError(t, err)
-			assert.Equal(t, test.expected, result)
-		}
-	}
+	runTestCases(t, tests, commonutils.FetchVersionSpecificBlockingQuery)
 }
 
 func TestFetchVersionSpecificIndividualQueries(t *testing.T) {
@@ -77,25 +67,4 @@ func TestFetchVersionSpecificIndividualQueries(t *testing.T) {
 	}
 
 	runTestCases(t, tests, commonutils.FetchVersionSpecificIndividualQueries)
-}
-
-func TestFetchSupportedWaitEventsQuery(t *testing.T) {
-	tests := []struct {
-		isRDS     bool
-		expected  string
-		expectErr bool
-	}{
-		{true, queries.WaitEventsFromPgStatActivity, false},
-		{false, queries.WaitEvents, false},
-	}
-
-	for _, test := range tests {
-		result, err := commonutils.FetchSupportedWaitEventsQuery(test.isRDS)
-		if test.expectErr {
-			assert.Error(t, err)
-		} else {
-			assert.NoError(t, err)
-			assert.Equal(t, test.expected, result)
-		}
-	}
 }

--- a/src/query-performance-monitoring/common-utils/query_fetch_helpers_test.go
+++ b/src/query-performance-monitoring/common-utils/query_fetch_helpers_test.go
@@ -36,22 +36,32 @@ func TestFetchVersionSpecificSlowQueries(t *testing.T) {
 		{commonutils.PostgresVersion11, "", true},
 	}
 
-	runTestCases(t, tests, commonutils.FetchVersionSpecificSlowQueries)
+	runTestCases(t, tests, commonutils.FetchVersionSpecificSlowQuery)
 }
 
 func TestFetchVersionSpecificBlockingQueries(t *testing.T) {
 	tests := []struct {
 		version   uint64
 		expected  string
+		isRDS     bool
 		expectErr bool
 	}{
-		{commonutils.PostgresVersion12, queries.BlockingQueriesForV12AndV13, false},
-		{commonutils.PostgresVersion13, queries.BlockingQueriesForV12AndV13, false},
-		{commonutils.PostgresVersion14, queries.BlockingQueriesForV14AndAbove, false},
-		{commonutils.PostgresVersion11, "", true},
+		{commonutils.PostgresVersion12, queries.BlockingQueriesForV12AndV13, false, false},
+		{commonutils.PostgresVersion13, queries.BlockingQueriesForV12AndV13, false, false},
+		{commonutils.PostgresVersion14, queries.BlockingQueriesForV14AndAbove, false, false},
+		{commonutils.PostgresVersion14, queries.RDSPostgresBlockingQueryForV14AndAbove, true, false},
+		{commonutils.PostgresVersion11, "", false, true},
 	}
 
-	runTestCases(t, tests, commonutils.FetchVersionSpecificBlockingQueries)
+	for _, test := range tests {
+		result, err := commonutils.FetchVersionSpecificBlockingQuery(test.version, test.isRDS)
+		if test.expectErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+			assert.Equal(t, test.expected, result)
+		}
+	}
 }
 
 func TestFetchVersionSpecificIndividualQueries(t *testing.T) {
@@ -67,4 +77,25 @@ func TestFetchVersionSpecificIndividualQueries(t *testing.T) {
 	}
 
 	runTestCases(t, tests, commonutils.FetchVersionSpecificIndividualQueries)
+}
+
+func TestFetchSupportedWaitEventsQuery(t *testing.T) {
+	tests := []struct {
+		isRDS     bool
+		expected  string
+		expectErr bool
+	}{
+		{true, queries.WaitEventsFromPgStatActivity, false},
+		{false, queries.WaitEvents, false},
+	}
+
+	for _, test := range tests {
+		result, err := commonutils.FetchSupportedWaitEventsQuery(test.isRDS)
+		if test.expectErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+			assert.Equal(t, test.expected, result)
+		}
+	}
 }

--- a/src/query-performance-monitoring/datamodels/performance_data_models.go
+++ b/src/query-performance-monitoring/datamodels/performance_data_models.go
@@ -15,21 +15,6 @@ type SlowRunningQueryMetrics struct {
 	IndividualQuery     *string  `db:"individual_query"      metric_name:"individual_query"           source_type:"attribute" ingest_data:"false"`
 }
 
-type SlowRunningQueryMetricsPgStat struct {
-	Newrelic            *string  `db:"newrelic"              metric_name:"newrelic"                   source_type:"attribute"  ingest_data:"false"`
-	QueryID             *string  `db:"query_id"              metric_name:"query_id"                   source_type:"attribute"`
-	QueryText           *string  `db:"query_text"            metric_name:"query_text"                 source_type:"attribute"`
-	DatabaseName        *string  `db:"database_name"         metric_name:"database_name"              source_type:"attribute"`
-	SchemaName          *string  `db:"schema_name"           metric_name:"schema_name"                source_type:"attribute"`
-	ExecutionCount      *int64   `db:"execution_count"       metric_name:"execution_count"            source_type:"gauge"`
-	AvgElapsedTimeMs    *float64 `db:"avg_elapsed_time_ms"   metric_name:"avg_elapsed_time_ms"        source_type:"gauge"`
-	AvgDiskReads        *float64 `db:"avg_disk_reads"        metric_name:"avg_disk_reads"             source_type:"gauge"`
-	AvgDiskWrites       *float64 `db:"avg_disk_writes"       metric_name:"avg_disk_writes"            source_type:"gauge"`
-	StatementType       *string  `db:"statement_type"        metric_name:"statement_type"             source_type:"attribute"`
-	CollectionTimestamp *string  `db:"collection_timestamp"  metric_name:"collection_timestamp"       source_type:"attribute"`
-	IndividualQuery     *string  `db:"individual_query"       metric_name:"individual_query"           source_type:"attribute" ingest_data:"false"`
-}
-
 type WaitEventMetrics struct {
 	WaitEventName       *string  `db:"wait_event_name"       metric_name:"wait_event_name"            source_type:"attribute"`
 	WaitCategory        *string  `db:"wait_category"         metric_name:"wait_category"              source_type:"attribute"`

--- a/src/query-performance-monitoring/datamodels/performance_data_models.go
+++ b/src/query-performance-monitoring/datamodels/performance_data_models.go
@@ -12,7 +12,24 @@ type SlowRunningQueryMetrics struct {
 	AvgDiskWrites       *float64 `db:"avg_disk_writes"       metric_name:"avg_disk_writes"            source_type:"gauge"`
 	StatementType       *string  `db:"statement_type"        metric_name:"statement_type"             source_type:"attribute"`
 	CollectionTimestamp *string  `db:"collection_timestamp"  metric_name:"collection_timestamp"       source_type:"attribute"`
+	IndividualQuery     *string  `db:"individual_query"      metric_name:"individual_query"           source_type:"attribute" ingest_data:"false"`
 }
+
+type SlowRunningQueryMetricsPgStat struct {
+	Newrelic            *string  `db:"newrelic"              metric_name:"newrelic"                   source_type:"attribute"  ingest_data:"false"`
+	QueryID             *string  `db:"query_id"              metric_name:"query_id"                   source_type:"attribute"`
+	QueryText           *string  `db:"query_text"            metric_name:"query_text"                 source_type:"attribute"`
+	DatabaseName        *string  `db:"database_name"         metric_name:"database_name"              source_type:"attribute"`
+	SchemaName          *string  `db:"schema_name"           metric_name:"schema_name"                source_type:"attribute"`
+	ExecutionCount      *int64   `db:"execution_count"       metric_name:"execution_count"            source_type:"gauge"`
+	AvgElapsedTimeMs    *float64 `db:"avg_elapsed_time_ms"   metric_name:"avg_elapsed_time_ms"        source_type:"gauge"`
+	AvgDiskReads        *float64 `db:"avg_disk_reads"        metric_name:"avg_disk_reads"             source_type:"gauge"`
+	AvgDiskWrites       *float64 `db:"avg_disk_writes"       metric_name:"avg_disk_writes"            source_type:"gauge"`
+	StatementType       *string  `db:"statement_type"        metric_name:"statement_type"             source_type:"attribute"`
+	CollectionTimestamp *string  `db:"collection_timestamp"  metric_name:"collection_timestamp"       source_type:"attribute"`
+	IndividualQuery     *string  `db:"individual_query"       metric_name:"individual_query"           source_type:"attribute" ingest_data:"false"`
+}
+
 type WaitEventMetrics struct {
 	WaitEventName       *string  `db:"wait_event_name"       metric_name:"wait_event_name"            source_type:"attribute"`
 	WaitCategory        *string  `db:"wait_category"         metric_name:"wait_category"              source_type:"attribute"`

--- a/src/query-performance-monitoring/performance-metrics/blocking_sessions.go
+++ b/src/query-performance-monitoring/performance-metrics/blocking_sessions.go
@@ -2,6 +2,7 @@ package performancemetrics
 
 import (
 	"fmt"
+	"github.com/newrelic/nri-postgresql/src/query-performance-monitoring/queries"
 
 	commonparameters "github.com/newrelic/nri-postgresql/src/query-performance-monitoring/common-parameters"
 
@@ -38,7 +39,7 @@ func PopulateBlockingMetrics(conn *performancedbconnection.PGSQLConnection, pgIn
 
 func getBlockingMetrics(conn *performancedbconnection.PGSQLConnection, cp *commonparameters.CommonParameters) ([]interface{}, error) {
 	var blockingQueriesMetricsList []interface{}
-	versionSpecificBlockingQuery, err := commonutils.FetchVersionSpecificBlockingQuery(cp.Version, cp.IsRds)
+	versionSpecificBlockingQuery, err := commonutils.FetchVersionSpecificBlockingQuery(cp.Version)
 	if err != nil {
 		log.Error("Unsupported postgres version: %v", err)
 		return nil, err
@@ -64,4 +65,70 @@ func getBlockingMetrics(conn *performancedbconnection.PGSQLConnection, cp *commo
 	}
 
 	return blockingQueriesMetricsList, nil
+}
+
+func PopulateBlockingMetricsPgStat(conn *performancedbconnection.PGSQLConnection, pgIntegration *integration.Integration, cp *commonparameters.CommonParameters, enabledExtensions map[string]bool, slowQueryMetrics []datamodels.SlowRunningQueryMetrics) {
+	log.Info("PopulateBlockingMetricsPgStat:{}", len(slowQueryMetrics))
+	isEligible := validations.CheckBlockingSessionMetricsFetchEligibility(enabledExtensions, cp.Version)
+	if !isEligible {
+		log.Debug("Extension 'pg_stat_statements' is not enabled or unsupported version.")
+		return
+	}
+	blockingQueriesMetricsList, blockQueryFetchErr := getBlockingMetricsPgStat(conn, cp)
+	if blockQueryFetchErr != nil {
+		log.Error("Error fetching Blocking queries: %v", blockQueryFetchErr)
+		return
+	}
+	if len(blockingQueriesMetricsList) == 0 {
+		log.Debug("No Blocking queries found.")
+		return
+	}
+	blockingSessionMetricInterface := getFilteredBlockingSessions(blockingQueriesMetricsList, slowQueryMetrics)
+	err := commonutils.IngestMetric(blockingSessionMetricInterface, "PostgresBlockingSessions", pgIntegration, cp)
+	if err != nil {
+		log.Error("Error ingesting Blocking queries: %v", err)
+		return
+	}
+}
+
+func getBlockingMetricsPgStat(conn *performancedbconnection.PGSQLConnection, cp *commonparameters.CommonParameters) ([]datamodels.BlockingSessionMetrics, error) {
+	var blockingQueriesMetricsList []datamodels.BlockingSessionMetrics
+	var query = fmt.Sprintf(queries.RDSPostgresBlockingQuery, cp.Databases, cp.QueryMonitoringCountThreshold)
+	rows, err := conn.Queryx(query)
+	if err != nil {
+		log.Error("Failed to execute query: %v", err)
+		return nil, commonutils.ErrUnExpectedError
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var blockingQueryMetric datamodels.BlockingSessionMetrics
+		if scanError := rows.StructScan(&blockingQueryMetric); scanError != nil {
+			return nil, scanError
+		}
+		blockingQueriesMetricsList = append(blockingQueriesMetricsList, blockingQueryMetric)
+	}
+	return blockingQueriesMetricsList, nil
+}
+
+func getFilteredBlockingSessions(blockingSessionMetrics []datamodels.BlockingSessionMetrics, slowQueryMetrics []datamodels.SlowRunningQueryMetrics) []interface{} {
+	filteredBlockingSessionMetricList := make([]interface{}, 0)
+	slowQueryTextMap := make(map[string]datamodels.SlowRunningQueryMetrics)
+	for _, metric := range slowQueryMetrics {
+		slowQueryTextMap[commonutils.AnonymizeAndNormalize(*metric.QueryText)] = metric
+	}
+	for _, blockingSessionMetric := range blockingSessionMetrics {
+		normalizedBlockingQuery := commonutils.AnonymizeAndNormalize(*blockingSessionMetric.BlockingQuery)
+		normalizedBlockedQuery := commonutils.AnonymizeAndNormalize(*blockingSessionMetric.BlockedQuery)
+		_, blockingQueryMetricExists := slowQueryTextMap[normalizedBlockingQuery]
+		_, blockedQueryMetricExists := slowQueryTextMap[normalizedBlockedQuery]
+
+		if blockingQueryMetricExists && blockedQueryMetricExists {
+			blockingSessionMetric.BlockingQuery = slowQueryTextMap[normalizedBlockingQuery].QueryText
+			blockingSessionMetric.BlockingQueryID = slowQueryTextMap[normalizedBlockingQuery].QueryID
+			blockingSessionMetric.BlockedQuery = slowQueryTextMap[normalizedBlockedQuery].QueryText
+			blockingSessionMetric.BlockedQueryID = slowQueryTextMap[normalizedBlockedQuery].QueryID
+			filteredBlockingSessionMetricList = append(filteredBlockingSessionMetricList, blockingSessionMetric)
+		}
+	}
+	return filteredBlockingSessionMetricList
 }

--- a/src/query-performance-monitoring/performance-metrics/blocking_sessions.go
+++ b/src/query-performance-monitoring/performance-metrics/blocking_sessions.go
@@ -15,11 +15,7 @@ import (
 )
 
 func PopulateBlockingMetrics(conn *performancedbconnection.PGSQLConnection, pgIntegration *integration.Integration, cp *commonparameters.CommonParameters, enabledExtensions map[string]bool) {
-	isEligible, enableCheckError := validations.CheckBlockingSessionMetricsFetchEligibility(enabledExtensions, cp.Version)
-	if enableCheckError != nil {
-		log.Error("Error executing query: %v in PopulateBlockingMetrics", enableCheckError)
-		return
-	}
+	isEligible := validations.CheckBlockingSessionMetricsFetchEligibility(enabledExtensions, cp.Version)
 	if !isEligible {
 		log.Debug("Extension 'pg_stat_statements' is not enabled or unsupported version.")
 		return
@@ -42,7 +38,7 @@ func PopulateBlockingMetrics(conn *performancedbconnection.PGSQLConnection, pgIn
 
 func getBlockingMetrics(conn *performancedbconnection.PGSQLConnection, cp *commonparameters.CommonParameters) ([]interface{}, error) {
 	var blockingQueriesMetricsList []interface{}
-	versionSpecificBlockingQuery, err := commonutils.FetchVersionSpecificBlockingQueries(cp.Version)
+	versionSpecificBlockingQuery, err := commonutils.FetchVersionSpecificBlockingQuery(cp.Version, cp.IsRds)
 	if err != nil {
 		log.Error("Unsupported postgres version: %v", err)
 		return nil, err

--- a/src/query-performance-monitoring/performance-metrics/blocking_sessions.go
+++ b/src/query-performance-monitoring/performance-metrics/blocking_sessions.go
@@ -68,7 +68,6 @@ func getBlockingMetrics(conn *performancedbconnection.PGSQLConnection, cp *commo
 }
 
 func PopulateBlockingMetricsPgStat(conn *performancedbconnection.PGSQLConnection, pgIntegration *integration.Integration, cp *commonparameters.CommonParameters, enabledExtensions map[string]bool, slowQueryMetrics []datamodels.SlowRunningQueryMetrics) {
-	log.Info("PopulateBlockingMetricsPgStat:{}", len(slowQueryMetrics))
 	isEligible := validations.CheckBlockingSessionMetricsFetchEligibility(enabledExtensions, cp.Version)
 	if !isEligible {
 		log.Debug("Extension 'pg_stat_statements' is not enabled or unsupported version.")

--- a/src/query-performance-monitoring/performance-metrics/individual_query_metrics_test.go
+++ b/src/query-performance-monitoring/performance-metrics/individual_query_metrics_test.go
@@ -48,6 +48,7 @@ func TestGetIndividualQueryMetrics(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+// TestPopulateIndividualQueryMetricsPgStat tests the PopulateIndividualQueryMetricsPgStat function which retrievs the queries from the slow query metrics as the extension pg_stat_monitor is not available for RDS/Aurora
 func TestPopulateIndividualQueryMetricsPgStat(t *testing.T) {
 	slowQueries := []datamodels.SlowRunningQueryMetrics{
 		{

--- a/src/query-performance-monitoring/performance-metrics/slow_query_metrics.go
+++ b/src/query-performance-monitoring/performance-metrics/slow_query_metrics.go
@@ -69,7 +69,7 @@ func PopulateSlowRunningMetricsPgStat(conn *performancedbconnection.PGSQLConnect
 	}
 	individualQueries := getIndividualQueriesFromPgStat(conn)
 	slowQueryMetricsList, _, err := getSlowRunningMetrics(conn, cp)
-	filteredSlowQueryMetrics, filteredSlowQueryMetricsInterface := getFilteredIndividualAndSlowMetrics(individualQueries, slowQueryMetricsList)
+	filteredSlowQueryMetrics, filteredSlowQueryMetricsInterface := getFilteredSlowMetrics(individualQueries, slowQueryMetricsList)
 	if err != nil {
 		log.Error("Error fetching slow-running queries: %v", err)
 		return nil
@@ -87,7 +87,7 @@ func PopulateSlowRunningMetricsPgStat(conn *performancedbconnection.PGSQLConnect
 	return filteredSlowQueryMetrics
 }
 
-func getFilteredIndividualAndSlowMetrics(individualQueries []string, slowQueryMetrics []datamodels.SlowRunningQueryMetrics) ([]datamodels.SlowRunningQueryMetrics, []interface{}) {
+func getFilteredSlowMetrics(individualQueries []string, slowQueryMetrics []datamodels.SlowRunningQueryMetrics) ([]datamodels.SlowRunningQueryMetrics, []interface{}) {
 	filteredSlowQueryMetrics := make([]datamodels.SlowRunningQueryMetrics, 0)
 	filteredSlowQueryMetricsInterface := make([]interface{}, 0)
 	individualQueryMap := make(map[string]string)

--- a/src/query-performance-monitoring/performance-metrics/slow_query_metrics.go
+++ b/src/query-performance-monitoring/performance-metrics/slow_query_metrics.go
@@ -95,8 +95,9 @@ func getFilteredIndividualAndSlowMetrics(individualQueries []string, slowQueryMe
 		individualQueryMap[commonutils.AnonymizeAndNormalize(individualQuery)] = individualQuery
 	}
 	for _, slowQueryMetric := range slowQueryMetrics {
-		if _, exists := individualQueryMap[commonutils.AnonymizeQueryText(*slowQueryMetric.QueryText)]; exists {
-			individualQuerySample := individualQueryMap[commonutils.AnonymizeQueryText(*slowQueryMetric.QueryText)]
+		normalizedSlowQueryText := commonutils.AnonymizeAndNormalize(*slowQueryMetric.QueryText)
+		if _, exists := individualQueryMap[normalizedSlowQueryText]; exists {
+			individualQuerySample := individualQueryMap[normalizedSlowQueryText]
 			slowQueryMetric.QueryText = &individualQuerySample
 			slowQueryMetrics = append(slowQueryMetrics, slowQueryMetric)
 			filteredSlowQueryMetricsInterface = append(filteredSlowQueryMetricsInterface, slowQueryMetric)

--- a/src/query-performance-monitoring/performance-metrics/slow_query_metrics.go
+++ b/src/query-performance-monitoring/performance-metrics/slow_query_metrics.go
@@ -98,9 +98,9 @@ func getFilteredIndividualAndSlowMetrics(individualQueries []string, slowQueryMe
 		normalizedSlowQueryText := commonutils.AnonymizeAndNormalize(*slowQueryMetric.QueryText)
 		if _, exists := individualQueryMap[normalizedSlowQueryText]; exists {
 			individualQuerySample := individualQueryMap[normalizedSlowQueryText]
-			slowQueryMetric.QueryText = &individualQuerySample
-			slowQueryMetrics = append(slowQueryMetrics, slowQueryMetric)
+			slowQueryMetric.IndividualQuery = &individualQuerySample
 			filteredSlowQueryMetricsInterface = append(filteredSlowQueryMetricsInterface, slowQueryMetric)
+			filteredSlowQueryMetrics = append(filteredSlowQueryMetrics, slowQueryMetric)
 		}
 	}
 	return filteredSlowQueryMetrics, filteredSlowQueryMetricsInterface

--- a/src/query-performance-monitoring/performance-metrics/slow_query_metrics.go
+++ b/src/query-performance-monitoring/performance-metrics/slow_query_metrics.go
@@ -2,6 +2,8 @@ package performancemetrics
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/newrelic/infra-integrations-sdk/v3/integration"
 	"github.com/newrelic/infra-integrations-sdk/v3/log"
 	performancedbconnection "github.com/newrelic/nri-postgresql/src/connection"
@@ -29,6 +31,10 @@ func getSlowRunningMetrics(conn *performancedbconnection.PGSQLConnection, cp *co
 		var slowQuery datamodels.SlowRunningQueryMetrics
 		if scanErr := rows.StructScan(&slowQuery); scanErr != nil {
 			return nil, nil, err
+		}
+		if slowQuery.QueryText != nil && strings.Contains(strings.ToLower(*slowQuery.QueryText), "alter") {
+			anonymizedQuery := commonutils.AnonymizeQueryText(*slowQuery.QueryText)
+			slowQuery.QueryText = &anonymizedQuery
 		}
 		slowQueryMetricsList = append(slowQueryMetricsList, slowQuery)
 		slowQueryMetricsListInterface = append(slowQueryMetricsListInterface, slowQuery)

--- a/src/query-performance-monitoring/performance-metrics/slow_query_metrics.go
+++ b/src/query-performance-monitoring/performance-metrics/slow_query_metrics.go
@@ -2,7 +2,6 @@ package performancemetrics
 
 import (
 	"fmt"
-
 	"github.com/newrelic/infra-integrations-sdk/v3/integration"
 	"github.com/newrelic/infra-integrations-sdk/v3/log"
 	performancedbconnection "github.com/newrelic/nri-postgresql/src/connection"
@@ -15,7 +14,7 @@ import (
 func getSlowRunningMetrics(conn *performancedbconnection.PGSQLConnection, cp *commonparameters.CommonParameters) ([]datamodels.SlowRunningQueryMetrics, []interface{}, error) {
 	var slowQueryMetricsList []datamodels.SlowRunningQueryMetrics
 	var slowQueryMetricsListInterface []interface{}
-	versionSpecificSlowQuery, err := commonutils.FetchVersionSpecificSlowQueries(cp.Version)
+	versionSpecificSlowQuery, err := commonutils.FetchVersionSpecificSlowQuery(cp.Version)
 	if err != nil {
 		log.Error("Unsupported postgres version: %v", err)
 		return nil, nil, err
@@ -38,11 +37,7 @@ func getSlowRunningMetrics(conn *performancedbconnection.PGSQLConnection, cp *co
 }
 
 func PopulateSlowRunningMetrics(conn *performancedbconnection.PGSQLConnection, pgIntegration *integration.Integration, cp *commonparameters.CommonParameters, enabledExtensions map[string]bool) []datamodels.SlowRunningQueryMetrics {
-	isEligible, err := validations.CheckSlowQueryMetricsFetchEligibility(enabledExtensions)
-	if err != nil {
-		log.Error("Error executing query: %v", err)
-		return nil
-	}
+	isEligible := validations.CheckSlowQueryMetricsFetchEligibility(enabledExtensions)
 	if !isEligible {
 		log.Debug("Extension 'pg_stat_statements' is not enabled or unsupported version.")
 		return nil
@@ -64,4 +59,48 @@ func PopulateSlowRunningMetrics(conn *performancedbconnection.PGSQLConnection, p
 		return nil
 	}
 	return slowQueryMetricsList
+}
+
+func PopulateSlowRunningMetricsPgStat(conn *performancedbconnection.PGSQLConnection, pgIntegration *integration.Integration, cp *commonparameters.CommonParameters, enabledExtensions map[string]bool) []datamodels.SlowRunningQueryMetrics {
+	isEligible := validations.CheckSlowQueryMetricsFetchEligibility(enabledExtensions)
+	if !isEligible {
+		log.Debug("Extension 'pg_stat_statements' is not enabled or unsupported version.")
+		return nil
+	}
+	individualQueries := getIndividualQueriesFromPgStat(conn)
+	slowQueryMetricsList, _, err := getSlowRunningMetrics(conn, cp)
+	filteredSlowQueryMetrics, filteredSlowQueryMetricsInterface := getFilteredIndividualAndSlowMetrics(individualQueries, slowQueryMetricsList)
+	if err != nil {
+		log.Error("Error fetching slow-running queries: %v", err)
+		return nil
+	}
+
+	if len(slowQueryMetricsList) == 0 {
+		log.Debug("No slow-running queries found.")
+		return nil
+	}
+	err = commonutils.IngestMetric(filteredSlowQueryMetricsInterface, "PostgresSlowQueries", pgIntegration, cp)
+	if err != nil {
+		log.Error("Error ingesting slow-running queries: %v", err)
+		return nil
+	}
+	return filteredSlowQueryMetrics
+}
+
+func getFilteredIndividualAndSlowMetrics(individualQueries []string, slowQueryMetrics []datamodels.SlowRunningQueryMetrics) ([]datamodels.SlowRunningQueryMetrics, []interface{}) {
+	filteredSlowQueryMetrics := make([]datamodels.SlowRunningQueryMetrics, 0)
+	filteredSlowQueryMetricsInterface := make([]interface{}, 0)
+	individualQueryMap := make(map[string]string)
+	for _, individualQuery := range individualQueries {
+		individualQueryMap[commonutils.AnonymizeAndNormalize(individualQuery)] = individualQuery
+	}
+	for _, slowQueryMetric := range slowQueryMetrics {
+		if _, exists := individualQueryMap[commonutils.AnonymizeQueryText(*slowQueryMetric.QueryText)]; exists {
+			individualQuerySample := individualQueryMap[commonutils.AnonymizeQueryText(*slowQueryMetric.QueryText)]
+			slowQueryMetric.QueryText = &individualQuerySample
+			slowQueryMetrics = append(slowQueryMetrics, slowQueryMetric)
+			filteredSlowQueryMetricsInterface = append(filteredSlowQueryMetricsInterface, slowQueryMetric)
+		}
+	}
+	return filteredSlowQueryMetrics, filteredSlowQueryMetricsInterface
 }

--- a/src/query-performance-monitoring/performance-metrics/slow_query_metrics.go
+++ b/src/query-performance-monitoring/performance-metrics/slow_query_metrics.go
@@ -61,6 +61,7 @@ func PopulateSlowRunningMetrics(conn *performancedbconnection.PGSQLConnection, p
 	return slowQueryMetricsList
 }
 
+// PopulateSlowRunningMetricsPgStat collects and ingests slow running query metrics. // Returns nil if an error occurs or if the required extension is not enabled.
 func PopulateSlowRunningMetricsPgStat(conn *performancedbconnection.PGSQLConnection, pgIntegration *integration.Integration, cp *commonparameters.CommonParameters, enabledExtensions map[string]bool) []datamodels.SlowRunningQueryMetrics {
 	isEligible := validations.CheckSlowQueryMetricsFetchEligibility(enabledExtensions)
 	if !isEligible {

--- a/src/query-performance-monitoring/performance-metrics/slow_query_metrics_test.go
+++ b/src/query-performance-monitoring/performance-metrics/slow_query_metrics_test.go
@@ -82,7 +82,7 @@ func TestGetFilteredIndividualAndSlowMetrics_MatchingQueries(t *testing.T) {
 		{QueryText: stringPointer("SELECT * FROM products")},
 	}
 
-	filteredMetrics, _ := getFilteredIndividualAndSlowMetrics(individualQueries, slowQueryMetrics)
+	filteredMetrics, _ := getFilteredSlowMetrics(individualQueries, slowQueryMetrics)
 
 	assert.Len(t, filteredMetrics, 1)
 	assert.Equal(t, "SELECT * FROM users", *filteredMetrics[0].QueryText)
@@ -95,7 +95,7 @@ func TestGetFilteredIndividualAndSlowMetrics_NoMatchingQueries(t *testing.T) {
 		{QueryText: stringPointer("SELECT * FROM products")},
 	}
 
-	filteredMetrics, filteredMetricsInterface := getFilteredIndividualAndSlowMetrics(individualQueries, slowQueryMetrics)
+	filteredMetrics, filteredMetricsInterface := getFilteredSlowMetrics(individualQueries, slowQueryMetrics)
 
 	assert.Len(t, filteredMetrics, 0)
 	assert.Len(t, filteredMetricsInterface, 0)
@@ -105,7 +105,7 @@ func TestGetFilteredIndividualAndSlowMetrics_EmptyInputs(t *testing.T) {
 	individualQueries := []string{}
 	slowQueryMetrics := []datamodels.SlowRunningQueryMetrics{}
 
-	filteredMetrics, filteredMetricsInterface := getFilteredIndividualAndSlowMetrics(individualQueries, slowQueryMetrics)
+	filteredMetrics, filteredMetricsInterface := getFilteredSlowMetrics(individualQueries, slowQueryMetrics)
 
 	assert.Len(t, filteredMetrics, 0)
 	assert.Len(t, filteredMetricsInterface, 0)
@@ -117,7 +117,7 @@ func TestGetFilteredIndividualAndSlowMetrics_DuplicateQueries(t *testing.T) {
 		{QueryText: stringPointer("SELECT * FROM users")},
 	}
 
-	filteredMetrics, filteredMetricsInterface := getFilteredIndividualAndSlowMetrics(individualQueries, slowQueryMetrics)
+	filteredMetrics, filteredMetricsInterface := getFilteredSlowMetrics(individualQueries, slowQueryMetrics)
 
 	assert.Len(t, filteredMetrics, 1)
 	assert.Len(t, filteredMetricsInterface, 1)

--- a/src/query-performance-monitoring/performance-metrics/slow_query_metrics_test.go
+++ b/src/query-performance-monitoring/performance-metrics/slow_query_metrics_test.go
@@ -5,6 +5,8 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/newrelic/nri-postgresql/src/query-performance-monitoring/datamodels"
+
 	"github.com/newrelic/nri-postgresql/src/args"
 	"github.com/newrelic/nri-postgresql/src/connection"
 	common_parameters "github.com/newrelic/nri-postgresql/src/query-performance-monitoring/common-parameters"
@@ -71,4 +73,57 @@ func TestGetSlowRunningMetricsUnsupportedVersion(t *testing.T) {
 	assert.EqualError(t, err, commonutils.ErrUnsupportedVersion.Error())
 	assert.Len(t, slowQueryList, 0)
 	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetFilteredIndividualAndSlowMetrics_MatchingQueries(t *testing.T) {
+	individualQueries := []string{"SELECT * FROM users", "SELECT * FROM orders"}
+	slowQueryMetrics := []datamodels.SlowRunningQueryMetrics{
+		{QueryText: stringPointer("SELECT * FROM users")},
+		{QueryText: stringPointer("SELECT * FROM products")},
+	}
+
+	filteredMetrics, _ := getFilteredIndividualAndSlowMetrics(individualQueries, slowQueryMetrics)
+
+	assert.Len(t, filteredMetrics, 1)
+	assert.Equal(t, "SELECT * FROM users", *filteredMetrics[0].QueryText)
+}
+
+func TestGetFilteredIndividualAndSlowMetrics_NoMatchingQueries(t *testing.T) {
+	individualQueries := []string{"SELECT * FROM customers"}
+	slowQueryMetrics := []datamodels.SlowRunningQueryMetrics{
+		{QueryText: stringPointer("SELECT * FROM users")},
+		{QueryText: stringPointer("SELECT * FROM products")},
+	}
+
+	filteredMetrics, filteredMetricsInterface := getFilteredIndividualAndSlowMetrics(individualQueries, slowQueryMetrics)
+
+	assert.Len(t, filteredMetrics, 0)
+	assert.Len(t, filteredMetricsInterface, 0)
+}
+
+func TestGetFilteredIndividualAndSlowMetrics_EmptyInputs(t *testing.T) {
+	individualQueries := []string{}
+	slowQueryMetrics := []datamodels.SlowRunningQueryMetrics{}
+
+	filteredMetrics, filteredMetricsInterface := getFilteredIndividualAndSlowMetrics(individualQueries, slowQueryMetrics)
+
+	assert.Len(t, filteredMetrics, 0)
+	assert.Len(t, filteredMetricsInterface, 0)
+}
+
+func TestGetFilteredIndividualAndSlowMetrics_DuplicateQueries(t *testing.T) {
+	individualQueries := []string{"SELECT * FROM users", "SELECT * FROM users"}
+	slowQueryMetrics := []datamodels.SlowRunningQueryMetrics{
+		{QueryText: stringPointer("SELECT * FROM users")},
+	}
+
+	filteredMetrics, filteredMetricsInterface := getFilteredIndividualAndSlowMetrics(individualQueries, slowQueryMetrics)
+
+	assert.Len(t, filteredMetrics, 1)
+	assert.Len(t, filteredMetricsInterface, 1)
+	assert.Equal(t, "SELECT * FROM users", *filteredMetrics[0].QueryText)
+}
+
+func stringPointer(s string) *string {
+	return &s
 }

--- a/src/query-performance-monitoring/performance-metrics/wait_event_metrics.go
+++ b/src/query-performance-monitoring/performance-metrics/wait_event_metrics.go
@@ -9,18 +9,11 @@ import (
 	commonparameters "github.com/newrelic/nri-postgresql/src/query-performance-monitoring/common-parameters"
 	commonutils "github.com/newrelic/nri-postgresql/src/query-performance-monitoring/common-utils"
 	"github.com/newrelic/nri-postgresql/src/query-performance-monitoring/datamodels"
-	"github.com/newrelic/nri-postgresql/src/query-performance-monitoring/queries"
 	"github.com/newrelic/nri-postgresql/src/query-performance-monitoring/validations"
 )
 
 func PopulateWaitEventMetrics(conn *performancedbconnection.PGSQLConnection, pgIntegration *integration.Integration, cp *commonparameters.CommonParameters, enabledExtensions map[string]bool) error {
-	var isEligible bool
-	var eligibleCheckErr error
-	isEligible, eligibleCheckErr = validations.CheckWaitEventMetricsFetchEligibility(enabledExtensions)
-	if eligibleCheckErr != nil {
-		log.Error("Error executing query: %v", eligibleCheckErr)
-		return commonutils.ErrUnExpectedError
-	}
+	var isEligible = validations.CheckWaitEventMetricsFetchEligibility(enabledExtensions)
 	if !isEligible {
 		log.Debug("Extension 'pg_wait_sampling' or 'pg_stat_statement' is not enabled or unsupported version.")
 		return commonutils.ErrNotEligible
@@ -44,7 +37,12 @@ func PopulateWaitEventMetrics(conn *performancedbconnection.PGSQLConnection, pgI
 
 func getWaitEventMetrics(conn *performancedbconnection.PGSQLConnection, cp *commonparameters.CommonParameters) ([]interface{}, error) {
 	var waitEventMetricsList []interface{}
-	var query = fmt.Sprintf(queries.WaitEvents, cp.Databases, cp.QueryMonitoringCountThreshold)
+	supportedWaitQuery, err := commonutils.FetchSupportedWaitEventsQuery(cp.IsRds)
+	if err != nil {
+		log.Error("Unsupported postgres version: %v", err)
+		return nil, err
+	}
+	var query = fmt.Sprintf(supportedWaitQuery, cp.Databases, cp.QueryMonitoringCountThreshold)
 	rows, err := conn.Queryx(query)
 	if err != nil {
 		return nil, err
@@ -55,6 +53,7 @@ func getWaitEventMetrics(conn *performancedbconnection.PGSQLConnection, cp *comm
 		if waitScanErr := rows.StructScan(&waitEvent); waitScanErr != nil {
 			return nil, err
 		}
+
 		waitEventMetricsList = append(waitEventMetricsList, waitEvent)
 	}
 	return waitEventMetricsList, nil

--- a/src/query-performance-monitoring/performance-metrics/wait_event_metrics.go
+++ b/src/query-performance-monitoring/performance-metrics/wait_event_metrics.go
@@ -2,6 +2,7 @@ package performancemetrics
 
 import (
 	"fmt"
+	"github.com/newrelic/nri-postgresql/src/query-performance-monitoring/queries"
 
 	"github.com/newrelic/infra-integrations-sdk/v3/integration"
 	"github.com/newrelic/infra-integrations-sdk/v3/log"
@@ -37,12 +38,7 @@ func PopulateWaitEventMetrics(conn *performancedbconnection.PGSQLConnection, pgI
 
 func getWaitEventMetrics(conn *performancedbconnection.PGSQLConnection, cp *commonparameters.CommonParameters) ([]interface{}, error) {
 	var waitEventMetricsList []interface{}
-	supportedWaitQuery, err := commonutils.FetchSupportedWaitEventsQuery(cp.IsRds)
-	if err != nil {
-		log.Error("Unsupported postgres version: %v", err)
-		return nil, err
-	}
-	var query = fmt.Sprintf(supportedWaitQuery, cp.Databases, cp.QueryMonitoringCountThreshold)
+	var query = fmt.Sprintf(queries.WaitEvents, cp.Databases, cp.QueryMonitoringCountThreshold)
 	rows, err := conn.Queryx(query)
 	if err != nil {
 		return nil, err
@@ -57,4 +53,59 @@ func getWaitEventMetrics(conn *performancedbconnection.PGSQLConnection, cp *comm
 		waitEventMetricsList = append(waitEventMetricsList, waitEvent)
 	}
 	return waitEventMetricsList, nil
+}
+
+func PopulateWaitEventMetricsPgStat(conn *performancedbconnection.PGSQLConnection, pgIntegration *integration.Integration, cp *commonparameters.CommonParameters, enabledExtensions map[string]bool, slowQueries []datamodels.SlowRunningQueryMetrics) error {
+	waitEventMetricsList, waitEventErr := getWaitEventMetricsPgStat(conn, cp)
+	if waitEventErr != nil {
+		log.Error("Error fetching wait event queries: %v", waitEventErr)
+		return commonutils.ErrUnExpectedError
+	}
+	if len(waitEventMetricsList) == 0 {
+		log.Debug("No wait event queries found.")
+		return nil
+	}
+	filteredWaitEvents := getFilteredWaitEvents(waitEventMetricsList, slowQueries)
+	err := commonutils.IngestMetric(filteredWaitEvents, "PostgresWaitEvents", pgIntegration, cp)
+	if err != nil {
+		log.Error("Error ingesting wait event queries: %v", err)
+		return err
+	}
+	return nil
+}
+
+func getWaitEventMetricsPgStat(conn *performancedbconnection.PGSQLConnection, cp *commonparameters.CommonParameters) ([]datamodels.WaitEventMetrics, error) {
+	var waitEventMetricsList []datamodels.WaitEventMetrics
+	var query = fmt.Sprintf(queries.WaitEventsFromPgStatActivity, cp.Databases, cp.QueryMonitoringCountThreshold)
+	rows, err := conn.Queryx(query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var waitEvent datamodels.WaitEventMetrics
+		if waitScanErr := rows.StructScan(&waitEvent); waitScanErr != nil {
+			return nil, err
+		}
+
+		waitEventMetricsList = append(waitEventMetricsList, waitEvent)
+	}
+	return waitEventMetricsList, nil
+}
+
+func getFilteredWaitEvents(waitEventMetrics []datamodels.WaitEventMetrics, slowQueryMetrics []datamodels.SlowRunningQueryMetrics) []interface{} {
+	filteredWaitEventMetricInterface := make([]interface{}, 0)
+	slowQueryTextMap := make(map[string]datamodels.SlowRunningQueryMetrics)
+	for _, metric := range slowQueryMetrics {
+		slowQueryTextMap[commonutils.AnonymizeAndNormalize(*metric.QueryText)] = metric
+	}
+	for _, waitEventMetric := range waitEventMetrics {
+		normalizedWaitEventQueryText := commonutils.AnonymizeAndNormalize(*waitEventMetric.QueryText)
+		if _, exists := slowQueryTextMap[normalizedWaitEventQueryText]; exists {
+			waitEventMetric.QueryText = slowQueryTextMap[normalizedWaitEventQueryText].QueryText
+			waitEventMetric.QueryID = slowQueryTextMap[normalizedWaitEventQueryText].QueryID
+			filteredWaitEventMetricInterface = append(filteredWaitEventMetricInterface, waitEventMetric)
+		}
+	}
+	return filteredWaitEventMetricInterface
 }

--- a/src/query-performance-monitoring/performance-metrics/wait_event_metrics_test.go
+++ b/src/query-performance-monitoring/performance-metrics/wait_event_metrics_test.go
@@ -1,6 +1,7 @@
 package performancemetrics
 
 import (
+	"database/sql/driver"
 	"fmt"
 	"regexp"
 	"testing"
@@ -8,6 +9,7 @@ import (
 	"github.com/newrelic/nri-postgresql/src/args"
 	"github.com/newrelic/nri-postgresql/src/connection"
 	common_parameters "github.com/newrelic/nri-postgresql/src/query-performance-monitoring/common-parameters"
+	"github.com/newrelic/nri-postgresql/src/query-performance-monitoring/datamodels"
 	"github.com/newrelic/nri-postgresql/src/query-performance-monitoring/queries"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
@@ -17,28 +19,67 @@ func TestGetWaitEventMetrics(t *testing.T) {
 	conn, mock := connection.CreateMockSQL(t)
 	args := args.ArgumentList{QueryMonitoringCountThreshold: 10}
 	databaseName := "testdb"
-	cp := common_parameters.SetCommonParameters(args, uint64(14), databaseName)
-
-	var query = fmt.Sprintf(queries.WaitEvents, databaseName, args.QueryMonitoringCountThreshold)
-	mock.ExpectQuery(regexp.QuoteMeta(query)).WillReturnRows(sqlmock.NewRows([]string{
+	version := uint64(14)
+	cp := common_parameters.SetCommonParameters(args, version, databaseName)
+	expectedQuery := queries.WaitEvents
+	query := fmt.Sprintf(expectedQuery, databaseName, args.QueryMonitoringCountThreshold)
+	rowData := []driver.Value{
+		"Locks:Lock", "Locks", 500.0, "2023-01-01T00:00:00Z", "queryid2", "SELECT 2", "testdb",
+	}
+	expectedRows := [][]driver.Value{
+		rowData, rowData,
+	}
+	mockRows := sqlmock.NewRows([]string{
 		"wait_event_name", "wait_category", "total_wait_time_ms", "collection_timestamp", "query_id", "query_text", "database_name",
-	}).AddRow(
-		"Locks:Lock", "Locks", 1000.0, "2023-01-01T00:00:00Z", "queryid1", "SELECT 1", "testdb",
-	))
-	waitEventsList, err := getWaitEventMetrics(conn, cp)
-
+	}).AddRow(rowData...).AddRow(rowData...)
+	mock.ExpectQuery(regexp.QuoteMeta(query)).WillReturnRows(mockRows)
+	waitEventMetricsList, err := getWaitEventMetrics(conn, cp)
+	compareMockRowsWithWaitMetrics(t, expectedRows, waitEventMetricsList)
 	assert.NoError(t, err)
-	assert.Len(t, waitEventsList, 1)
+	assert.Len(t, waitEventMetricsList, 2)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func compareMockRowsWithWaitMetrics(t *testing.T, expectedRows [][]driver.Value, waitEventMetricsList []any) {
+	assert.Equal(t, 2, len(waitEventMetricsList))
+	for index := range waitEventMetricsList {
+		waitEvents := waitEventMetricsList[index].(datamodels.WaitEventMetrics)
+		assert.Equal(t, expectedRows[index][0], *waitEvents.WaitEventName)
+		assert.Equal(t, expectedRows[index][1], *waitEvents.WaitCategory)
+		assert.Equal(t, expectedRows[index][2], *waitEvents.TotalWaitTimeMs)
+		assert.Equal(t, expectedRows[index][3], *waitEvents.CollectionTimestamp)
+		assert.Equal(t, expectedRows[index][4], *waitEvents.QueryID)
+		assert.Equal(t, expectedRows[index][5], *waitEvents.QueryText)
+		assert.Equal(t, expectedRows[index][6], *waitEvents.DatabaseName)
+	}
+}
+func TestGetWaitEventMetricsFromPgStatActivity(t *testing.T) {
+	conn, mock := connection.CreateMockSQL(t)
+	args := args.ArgumentList{QueryMonitoringCountThreshold: 10, Hostname: "testhost.rds.amazonaws.com"}
+	databaseName := "testdb"
+
+	cp := common_parameters.SetCommonParameters(args, uint64(14), databaseName)
+	query := fmt.Sprintf(queries.WaitEventsFromPgStatActivity, databaseName, args.QueryMonitoringCountThreshold)
+	mock.ExpectQuery(regexp.QuoteMeta(query)).WillReturnRows(sqlmock.NewRows([]string{
+		"wait_event_name", "wait_category", "total_wait_time_ms", "collection_timestamp", "query_id", "query_text", "database_name",
+	}).AddRow(
+		"Locks:Lock", "Locks", 500.0, "2023-01-01T00:00:00Z", "queryid2", "SELECT 2", "testdb",
+	))
+	waitEventsList, err := getWaitEventMetrics(conn, cp)
+	assert.NoError(t, err)
+	assert.Len(t, waitEventsList, 1)
+
+	// Ensure all expectations were met
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
 func TestGetWaitEventEmptyMetrics(t *testing.T) {
 	conn, mock := connection.CreateMockSQL(t)
-	args := args.ArgumentList{QueryMonitoringCountThreshold: 10}
+	args := args.ArgumentList{QueryMonitoringCountThreshold: 10, Hostname: "testhost"}
 	databaseName := "testdb"
-	cp := common_parameters.SetCommonParameters(args, uint64(14), databaseName)
-
-	var query = fmt.Sprintf(queries.WaitEvents, databaseName, args.QueryMonitoringCountThreshold)
+	version := uint64(14)
+	cp := common_parameters.SetCommonParameters(args, version, databaseName)
+	expectedQuery := queries.WaitEvents
+	query := fmt.Sprintf(expectedQuery, databaseName, args.QueryMonitoringCountThreshold)
 	mock.ExpectQuery(regexp.QuoteMeta(query)).WillReturnRows(sqlmock.NewRows([]string{
 		"wait_event_name", "wait_category", "total_wait_time_ms", "collection_timestamp", "query_id", "query_text", "database_name",
 	}))

--- a/src/query-performance-monitoring/queries/queries.go
+++ b/src/query-performance-monitoring/queries/queries.go
@@ -111,7 +111,7 @@ const (
 	ORDER BY total_wait_time_ms DESC -- Order by the total wait time in descending order
 	LIMIT %d; -- Limit the number of results`
 
-	// WaitEvents retrieves wait events and their statistics from pg_stat_activity
+	// WaitEvents retrieves wait events and their statistics from pg_stat_activity and doesnt involve joining pg_stat_staments as query id is missing in pg_stat_activity
 	WaitEventsFromPgStatActivity = `WITH wait_history AS (
         SELECT
             sa.pid, -- Process ID
@@ -176,6 +176,7 @@ const (
 		ORDER BY blocked_activity.query_start ASC -- Order by the start time of the blocked query in ascending order
 		LIMIT %d; -- Limit the number of results`
 
+	// RDSPostgresBlockingQuery retrieves blocking session events and their statistics from pg_stat_activity and doesnt involve joining pg_stat_staments as query id is missing in pg_stat_activity
 	RDSPostgresBlockingQuery = `SELECT 'newrelic' as newrelic, -- Common value to filter with like operator in slow query metrics
 		  blocked_activity.pid AS blocked_pid, -- Process ID of the blocked query
 		  blocked_activity.query AS blocked_query, -- Blocked query text truncated to 4095 characters
@@ -254,6 +255,7 @@ const (
 		 exec_time_ms DESC -- Order by average execution time in descending order
 		LIMIT %d; -- Limit the number of results`
 
+	// IndividualQueryFromPgStat retrieves currently running or last executed query of  DB connections
 	IndividualQueryFromPgStat = "select query  from pg_stat_activity where query is not null and query !='';"
 
 	// IndividualQuerySearchV12 retrieves individual query statistics for PostgreSQL version 12

--- a/src/query-performance-monitoring/query_performance_main.go
+++ b/src/query-performance-monitoring/query_performance_main.go
@@ -79,6 +79,14 @@ func populateQueryPerformanceMetrics(newConnection *performancedbconnection.PGSQ
 		performancemetrics.PopulateExecutionPlanMetrics(individualQueries, pgIntegration, cp, connectionInfo)
 		log.Debug("PopulateExecutionPlanMetrics completed in ", time.Since(start))
 	} else {
+		/*
+			Currently, there isn't an extension like pg_stat_monitor for RDS/Aurora that retrieves individual queries along with their CPU
+			and execution times. To address this, we utilize pg_stat_activity to capture active or last executed queries in a database connection.
+			We then correlate these queries with metrics related to slow performance, waiting sessions, and blocking sessions, as well as execution plans,
+			in order to establish connections between these metrics. Although we cannot join pg_stat_statements with all other metrics using a query ID
+			for each metric collection query, we can join pg_stat_statements through the query text. This process involves anonymizing and normalizing
+			both individual and slow queries for accurate correlation.
+		*/
 		start := time.Now()
 		log.Debug("Starting PopulateSlowQueriesPgStat at ", start)
 		slowQueries := performancemetrics.PopulateSlowRunningMetricsPgStat(newConnection, pgIntegration, cp, enabledExtensions)

--- a/src/query-performance-monitoring/query_performance_main.go
+++ b/src/query-performance-monitoring/query_performance_main.go
@@ -103,12 +103,12 @@ func populateQueryPerformanceMetrics(newConnection *performancedbconnection.PGSQ
 		log.Debug("PopulateExecutionPlanMetrics completed in ", time.Since(start))
 
 		start = time.Now()
-		log.Debug("Starting PopulateWaitEventMetrics at ", start)
+		log.Debug("Starting PopulateWaitEventMetricsPgStat at ", start)
 		_ = performancemetrics.PopulateWaitEventMetricsPgStat(newConnection, pgIntegration, cp, enabledExtensions, slowQueries)
 		log.Debug("PopulateWaitEventMetrics completed in ", time.Since(start))
 
 		start = time.Now()
-		log.Debug("Starting PopulateBlockingMetrics at ", start)
+		log.Debug("Starting PopulateBlockingMetricsPgStat at ", start)
 		performancemetrics.PopulateBlockingMetricsPgStat(newConnection, pgIntegration, cp, enabledExtensions, slowQueries)
 		log.Debug("PopulateBlockingMetrics completed in ", time.Since(start))
 	}

--- a/src/query-performance-monitoring/query_performance_main.go
+++ b/src/query-performance-monitoring/query_performance_main.go
@@ -52,18 +52,18 @@ func populateQueryPerformanceMetrics(newConnection *performancedbconnection.PGSQ
 		log.Error("Error fetching extensions: ", err)
 		return
 	}
-	start := time.Now()
-	log.Debug("Starting PopulateWaitEventMetrics at ", start)
-	_ = performancemetrics.PopulateWaitEventMetrics(newConnection, pgIntegration, cp, enabledExtensions)
-	log.Debug("PopulateWaitEventMetrics completed in ", time.Since(start))
 
-	start = time.Now()
-	log.Debug("Starting PopulateBlockingMetrics at ", start)
-	performancemetrics.PopulateBlockingMetrics(newConnection, pgIntegration, cp, enabledExtensions)
-	log.Debug("PopulateBlockingMetrics completed in ", time.Since(start))
-
-	// This check ensures metrics are collected even if the pg_stat_monitor extension is not enabled, as it alters the method of retrieving metrics and execution plans from different extensions.
 	if !cp.IsRds {
+		start := time.Now()
+		log.Debug("Starting PopulateWaitEventMetrics at ", start)
+		_ = performancemetrics.PopulateWaitEventMetrics(newConnection, pgIntegration, cp, enabledExtensions)
+		log.Debug("PopulateWaitEventMetrics completed in ", time.Since(start))
+
+		start = time.Now()
+		log.Debug("Starting PopulateBlockingMetrics at ", start)
+		performancemetrics.PopulateBlockingMetrics(newConnection, pgIntegration, cp, enabledExtensions)
+		log.Debug("PopulateBlockingMetrics completed in ", time.Since(start))
+
 		start = time.Now()
 		log.Debug("Starting PopulateSlowRunningMetrics at ", start)
 		slowRunningQueries := performancemetrics.PopulateSlowRunningMetrics(newConnection, pgIntegration, cp, enabledExtensions)
@@ -79,7 +79,7 @@ func populateQueryPerformanceMetrics(newConnection *performancedbconnection.PGSQ
 		performancemetrics.PopulateExecutionPlanMetrics(individualQueries, pgIntegration, cp, connectionInfo)
 		log.Debug("PopulateExecutionPlanMetrics completed in ", time.Since(start))
 	} else {
-		start = time.Now()
+		start := time.Now()
 		log.Debug("Starting PopulateSlowQueriesPgStat at ", start)
 		slowQueries := performancemetrics.PopulateSlowRunningMetricsPgStat(newConnection, pgIntegration, cp, enabledExtensions)
 		log.Debug("PopulateSlowQueriesPgStat completed in ", time.Since(start))
@@ -93,5 +93,15 @@ func populateQueryPerformanceMetrics(newConnection *performancedbconnection.PGSQ
 		log.Debug("Starting PopulateExecutionPlanMetrics at ", start)
 		performancemetrics.PopulateExecutionPlanMetrics(individualQueries, pgIntegration, cp, connectionInfo)
 		log.Debug("PopulateExecutionPlanMetrics completed in ", time.Since(start))
+
+		start = time.Now()
+		log.Debug("Starting PopulateWaitEventMetrics at ", start)
+		_ = performancemetrics.PopulateWaitEventMetricsPgStat(newConnection, pgIntegration, cp, enabledExtensions, slowQueries)
+		log.Debug("PopulateWaitEventMetrics completed in ", time.Since(start))
+
+		start = time.Now()
+		log.Debug("Starting PopulateBlockingMetrics at ", start)
+		performancemetrics.PopulateBlockingMetricsPgStat(newConnection, pgIntegration, cp, enabledExtensions, slowQueries)
+		log.Debug("PopulateBlockingMetrics completed in ", time.Since(start))
 	}
 }

--- a/src/query-performance-monitoring/validations/performance_metrics_validations.go
+++ b/src/query-performance-monitoring/validations/performance_metrics_validations.go
@@ -25,24 +25,24 @@ func FetchAllExtensions(conn *performancedbconnection.PGSQLConnection) (map[stri
 	return enabledExtensions, nil
 }
 
-func CheckSlowQueryMetricsFetchEligibility(enabledExtensions map[string]bool) (bool, error) {
-	return enabledExtensions["pg_stat_statements"], nil
+func CheckSlowQueryMetricsFetchEligibility(enabledExtensions map[string]bool) bool {
+	return enabledExtensions[commonutils.PgStatStatementExtension]
 }
 
-func CheckWaitEventMetricsFetchEligibility(enabledExtensions map[string]bool) (bool, error) {
-	return enabledExtensions["pg_wait_sampling"] && enabledExtensions["pg_stat_statements"], nil
+func CheckWaitEventMetricsFetchEligibility(enabledExtensions map[string]bool) bool {
+	return enabledExtensions[commonutils.PgStatStatementExtension]
 }
 
-func CheckBlockingSessionMetricsFetchEligibility(enabledExtensions map[string]bool, version uint64) (bool, error) {
+func CheckBlockingSessionMetricsFetchEligibility(enabledExtensions map[string]bool, version uint64) bool {
 	// Version 12 and 13 do not require the pg_stat_statements extension
 	if version == commonutils.PostgresVersion12 || version == commonutils.PostgresVersion13 {
-		return true, nil
+		return true
 	}
-	return enabledExtensions["pg_stat_statements"], nil
+	return enabledExtensions[commonutils.PgStatStatementExtension]
 }
 
-func CheckIndividualQueryMetricsFetchEligibility(enabledExtensions map[string]bool) (bool, error) {
-	return enabledExtensions["pg_stat_monitor"], nil
+func CheckIndividualQueryMetricsFetchEligibility(enabledExtensions map[string]bool) bool {
+	return enabledExtensions[commonutils.PgStatMonitorExtension]
 }
 
 func CheckPostgresVersionSupportForQueryMonitoring(version uint64) bool {

--- a/src/query-performance-monitoring/validations/performance_metrics_validations.go
+++ b/src/query-performance-monitoring/validations/performance_metrics_validations.go
@@ -30,7 +30,7 @@ func CheckSlowQueryMetricsFetchEligibility(enabledExtensions map[string]bool) bo
 }
 
 func CheckWaitEventMetricsFetchEligibility(enabledExtensions map[string]bool) bool {
-	return enabledExtensions[commonutils.PgStatStatementExtension]
+	return enabledExtensions[commonutils.PgStatStatementExtension] && enabledExtensions[commonutils.PgWaitSamplingExtension]
 }
 
 func CheckBlockingSessionMetricsFetchEligibility(enabledExtensions map[string]bool, version uint64) bool {

--- a/tests/postgresqlperf_test.go
+++ b/tests/postgresqlperf_test.go
@@ -91,12 +91,6 @@ func TestIntegrationWithDatabaseLoadPerfEnabled(t *testing.T) {
 			containers: perfContainers,
 			args:       []string{`-collection_list=all`},
 		},
-		{
-			name:                "Performance metrics collection test with query monitoring only flag enabled",
-			expectedSampleTypes: newSampleTypes,
-			containers:          perfContainers,
-			args:                []string{`-collection_list=all`, `-query_monitoring_only=true`},
-		},
 	}
 
 	for _, tt := range tests {

--- a/tests/postgresqlperf_test.go
+++ b/tests/postgresqlperf_test.go
@@ -39,7 +39,7 @@ var (
 	port       = flag.Int("port", defaultPort, "Postgresql port")
 	database   = flag.String("database", defaultDB, "Postgresql database")
 
-	allSampleTypes = []string {
+	allSampleTypes = []string{
 		"PostgresqlInstanceSample",
 		"PostgresSlowQueries",
 		"PostgresWaitEvents",

--- a/tests/postgresqlperf_test.go
+++ b/tests/postgresqlperf_test.go
@@ -47,6 +47,13 @@ var (
 		"PostgresIndividualQueries",
 		"PostgresExecutionPlanMetrics",
 	}
+	newSampleTypes = []string{
+		"PostgresSlowQueries",
+		"PostgresWaitEvents",
+		"PostgresBlockingSessions",
+		"PostgresIndividualQueries",
+		"PostgresExecutionPlanMetrics",
+	}
 )
 
 func TestMain(m *testing.M) {
@@ -83,6 +90,12 @@ func TestIntegrationWithDatabaseLoadPerfEnabled(t *testing.T) {
 			},
 			containers: perfContainers,
 			args:       []string{`-collection_list=all`},
+		},
+		{
+			name: "Performance metrics collection test with query moniotoring only flag enabled",
+			expectedSampleTypes: newSampleTypes,
+			containers: perfContainers,
+			args:       []string{`-collection_list=all`, `-query_monitoring_only=true`},
 		},
 	}
 

--- a/tests/postgresqlperf_test.go
+++ b/tests/postgresqlperf_test.go
@@ -92,10 +92,10 @@ func TestIntegrationWithDatabaseLoadPerfEnabled(t *testing.T) {
 			args:       []string{`-collection_list=all`},
 		},
 		{
-			name: "Performance metrics collection test with query moniotoring only flag enabled",
+			name:                "Performance metrics collection test with query monitoring only flag enabled",
 			expectedSampleTypes: newSampleTypes,
-			containers: perfContainers,
-			args:       []string{`-collection_list=all`, `-query_monitoring_only=true`},
+			containers:          perfContainers,
+			args:                []string{`-collection_list=all`, `-query_monitoring_only=true`},
 		},
 	}
 


### PR DESCRIPTION
Added Query Performance Monitoring support for Aurora and RDS

- We have extensions supported on-host that are responsible for collecting metrics. However, Aurora and standard RDS do not support extensions such as `pg_wait_sampling` (which handles wait events) and `pg_stat_monitor` (which handles individual queries and execution plans). In the extended support for Aurora/RDS, we gather wait events, individual  queries and execution plan from `pg_stat_activity`, which is the default view.
- Attached is a [document](https://newrelic.atlassian.net/wiki/spaces/GROWTHCXP/pages/4282942679/Aurora+RDS+extended+support+for+nri-postgresql) that provides a detailed explanation of the scenario.

Added QUERY_MONITORING_ONLY  flag to enable only query monitoring feature
- We introduced the QUERY_MONITORING_ONLY flag in the arguments. When set to true, it ensures that only query performance monitoring metrics, such as PostgresSlowQueries, PostgresWaitEvents, PostgresBlockingSessions, PostgresIndividualQueries, and PostgresExecutionPlanMetrics, are pushed to New Relic. Consequently, existing events like PostgresqlInstanceSample,PostgresqlDatabaseSample,PostgresqlIndexSample,PostgresqlTableSample will not be sent.