### PR TITLE
Add total_wait_time for wait events of RDS/Aurora DB monitoring  (#117)

### DIFF
--- a/src/query-performance-monitoring/datamodels/performance_data_models.go
+++ b/src/query-performance-monitoring/datamodels/performance_data_models.go
@@ -41,10 +41,11 @@ type IndividualQueryMetrics struct {
 	QueryText       *string  `json:"query" db:"query" metric_name:"query_text" source_type:"attribute"`
 	QueryID         *string  `json:"queryid" db:"queryid" metric_name:"query_id" source_type:"attribute"`
 	DatabaseName    *string  `json:"datname" db:"datname" metric_name:"database_name" source_type:"attribute"`
-	AvgCPUTimeInMS  *float64 `json:"cpu_time_ms" db:"cpu_time_ms" metric_name:"cpu_time_ms" source_type:"gauge"`
+	CPUTimeInMS     *float64 `json:"cpu_time_ms" db:"cpu_time_ms" metric_name:"cpu_time_ms" source_type:"gauge"`
 	PlanID          *string  `json:"planid" db:"planid" metric_name:"plan_id" source_type:"attribute"`
 	RealQueryText   *string  `ingest_data:"false"`
-	AvgExecTimeInMs *float64 `json:"exec_time_ms" db:"exec_time_ms" metric_name:"exec_time_ms" source_type:"gauge"`
+	ExecTimeInMs    *float64 `json:"exec_time_ms" db:"exec_time_ms" metric_name:"exec_time_ms" source_type:"gauge"`
+	AvgExecTimeInMs *float64 `json:"avg_exec_time_ms" metric_name:"avg_exec_time_ms" source_type:"gauge"`
 	Newrelic        *string  `db:"newrelic"              metric_name:"newrelic"            source_type:"attribute"  ingest_data:"false"`
 }
 

--- a/src/query-performance-monitoring/performance-metrics/individual_query_metrics.go
+++ b/src/query-performance-monitoring/performance-metrics/individual_query_metrics.go
@@ -64,6 +64,7 @@ func getIndividualQueryMetrics(conn *performancedbconnection.PGSQLConnection, sl
 		defer rows.Close()
 		individualQuerySamplesList := processRows(rows, anonymizedQueriesByDB)
 		for _, individualQuery := range individualQuerySamplesList {
+			individualQuery.AvgExecTimeInMs = slowRunningMetric.AvgElapsedTimeMs
 			individualQueryMetricsList = append(individualQueryMetricsList, individualQuery)
 			individualQueryMetricsListInterface = append(individualQueryMetricsListInterface, individualQuery)
 		}
@@ -126,6 +127,7 @@ func PopulateIndividualQueryMetricsPgStat(slowQueries []datamodels.SlowRunningQu
 		individualQueryMetric.DatabaseName = slowRunningMetric.DatabaseName
 		individualQueryMetric.QueryText = slowRunningMetric.QueryText
 		individualQueryMetric.RealQueryText = slowRunningMetric.IndividualQuery
+		individualQueryMetric.AvgExecTimeInMs = slowRunningMetric.AvgElapsedTimeMs
 		generatedPlanID, err := commonutils.GeneratePlanID()
 		if err != nil {
 			log.Error("Error generating plan ID: %v", err)

--- a/src/query-performance-monitoring/performance-metrics/individual_query_metrics_test.go
+++ b/src/query-performance-monitoring/performance-metrics/individual_query_metrics_test.go
@@ -52,16 +52,18 @@ func TestGetIndividualQueryMetrics(t *testing.T) {
 func TestPopulateIndividualQueryMetricsPgStat(t *testing.T) {
 	slowQueries := []datamodels.SlowRunningQueryMetrics{
 		{
-			QueryID:         stringPtr("query1"),
-			DatabaseName:    stringPtr("testdb"),
-			QueryText:       stringPtr("SELECT * FROM test where id = $1"),
-			IndividualQuery: stringPtr("SELECT * FROM test where id = 1"),
+			QueryID:          stringPtr("query1"),
+			DatabaseName:     stringPtr("testdb"),
+			QueryText:        stringPtr("SELECT * FROM test where id = $1"),
+			IndividualQuery:  stringPtr("SELECT * FROM test where id = 1"),
+			AvgElapsedTimeMs: floatPtr(100),
 		},
 		{
-			QueryID:         stringPtr("query2"),
-			DatabaseName:    stringPtr("testdb"),
-			QueryText:       stringPtr("SELECT * FROM users where id = $1"),
-			IndividualQuery: stringPtr("SELECT * FROM users where id = 1"),
+			QueryID:          stringPtr("query2"),
+			DatabaseName:     stringPtr("testdb"),
+			QueryText:        stringPtr("SELECT * FROM users where id = $1"),
+			IndividualQuery:  stringPtr("SELECT * FROM users where id = 1"),
+			AvgElapsedTimeMs: floatPtr(100),
 		},
 	}
 	pgIntegration, _ := integration.New("test", "1.0.0")
@@ -76,6 +78,7 @@ func TestPopulateIndividualQueryMetricsPgStat(t *testing.T) {
 	assert.Equal(t, "testdb", *result[0].DatabaseName)
 	assert.Equal(t, "SELECT * FROM test where id = $1", *result[0].QueryText)
 	assert.Equal(t, "SELECT * FROM test where id = 1", *result[0].RealQueryText)
+	assert.Equal(t, float64(100), *result[0].AvgExecTimeInMs)
 }
 
 func TestPopulateIndividualQueryMetricsPgStatEmpty(t *testing.T) {
@@ -91,4 +94,8 @@ func TestPopulateIndividualQueryMetricsPgStatEmpty(t *testing.T) {
 
 func stringPtr(s string) *string {
 	return &s
+}
+
+func floatPtr(i float64) *float64 {
+	return &i
 }

--- a/tests/testdata/individual-queries-schema.json
+++ b/tests/testdata/individual-queries-schema.json
@@ -70,6 +70,10 @@
                                     "type": "number",
                                     "minimum": 0
                                 },
+                                "avg_exec_time_ms": {
+                                    "type": "number",
+                                    "minimum": 0
+                                },
                                 "database_name": {
                                     "type": "string"
                                 },


### PR DESCRIPTION
* Added total wait time for wait events

* added average execution time in individual query event

Below is the response from NRQL after the change
"events": [
          {
            "agentName": "Infrastructure",
            "agentVersion": "1.65.1",
            "avg_exec_time_ms": 1.916,
            "awsAccountId": "997831524462",
            "awsAvailabilityZone": "us-east-1b",
            "awsRegion": "us-east-1",
            "coreCount": "2",
            "database_name": "analytics",
            "displayName": "pg-instance:postgres-rds-sandbox.cszoyw6q4wm8.us-east-1.rds.amazonaws.com:5432",
            "ec2AmiId": "ami-05ec1e5f7cfe5ef59",
            "entityGuid": "NDE4NDIzOHxJTkZSQXxOQXwtNjM0OTc3ODYwMTE0ODYzNDYwNQ",
            "entityId": "-6349778601148634605",
            "entityKey": "pg-instance:postgres-rds-sandbox.cszoyw6q4wm8.us-east-1.rds.amazonaws.com:5432",
            "entityName": "pg-instance:postgres-rds-sandbox.cszoyw6q4wm8.us-east-1.rds.amazonaws.com:5432",
            "event_type": "PostgresIndividualQueries",
            "externalKey": "pg-instance:postgres-rds-sandbox.cszoyw6q4wm8.us-east-1.rds.amazonaws.com:5432",
            "fullHostname": "ip-10-0-2-82.ec2.internal",
            "host": "ip-10-0-2-82",
            "hostStatus": "running",
            "hostname": "ip-10-0-2-82",
            "instanceType": "t2.medium",
            "integrationName": "com.newrelic.postgresql",
            "integrationVersion": "0.0.0",
            "kernelVersion": "6.8.0-1030-aws",
            "label.env": "production",
            "label.role": "postgresql",
            "linuxDistribution": "Ubuntu 22.04.5 LTS",
            "nr.entityType": "PostgreSQLInstance",
            "nr.ingestTimeMs": 1751630818000,
            "nr.invalidAttributeCount": 2,
            "nr_deployed_by": "newrelic-cli",
            "operatingSystem": "linux",
            "plan_id": "927216-20250704120658",
            "processorCount": "2",
            "query_id": "5883147329021510023",
            "query_text": "SELECT name, setting, boot_val, reset_val FROM pg_settings",
            "reportingAgent": "i-0e0dc0595a2e8eae5",
            "systemMemoryBytes": "4102197248",
            "timestamp": 1751630818000
          },

---------