### PR TITLE
fix: Support PgBouncer admin console mode (DATABASE=pgbouncer)

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -60,10 +60,21 @@ func main() {
 	}
 
 	connectionInfo := connection.DefaultConnectionInfo(&args)
-	collectionList, err := collection.BuildCollectionList(args, connectionInfo)
-	if err != nil {
-		log.Error("Error creating list of entities to collect: %s", err)
-		os.Exit(1)
+
+	// When connecting directly to PgBouncer admin console (DATABASE=pgbouncer),
+	// skip building collection list as it requires PostgreSQL-specific queries
+	var collectionList collection.DatabaseList
+	if args.Pgbouncer && args.Database == "pgbouncer" {
+		// PgBouncer admin console mode - initialize empty collection list
+		collectionList = collection.DatabaseList{}
+	} else {
+		// Standard PostgreSQL mode - build collection list normally
+		var err error
+		collectionList, err = collection.BuildCollectionList(args, connectionInfo)
+		if err != nil {
+			log.Error("Error creating list of entities to collect: %s", err)
+			os.Exit(1)
+		}
 	}
 	instance, err := pgIntegration.Entity(fmt.Sprintf("%s:%s", args.Hostname, args.Port), "pg-instance")
 	if err != nil {
@@ -78,12 +89,18 @@ func main() {
 	}
 
 	if args.HasInventory() {
-		con, err := connectionInfo.NewConnection(connectionInfo.DatabaseName())
-		if err != nil {
-			log.Error("Inventory collection failed: error creating connection to PostgreSQL: %s", err.Error())
+		// Skip inventory collection when connected to PgBouncer admin console
+		// as it requires PostgreSQL-specific system queries
+		if args.Pgbouncer && args.Database == "pgbouncer" {
+			log.Debug("Skipping inventory collection in PgBouncer admin console mode")
 		} else {
-			defer con.Close()
-			inventory.PopulateInventory(instance, con)
+			con, err := connectionInfo.NewConnection(connectionInfo.DatabaseName())
+			if err != nil {
+				log.Error("Inventory collection failed: error creating connection to PostgreSQL: %s", err.Error())
+			} else {
+				defer con.Close()
+				inventory.PopulateInventory(instance, con)
+			}
 		}
 	}
 
@@ -92,7 +109,13 @@ func main() {
 	}
 
 	if args.EnableQueryMonitoring {
-		queryperformancemonitoring.QueryPerformanceMain(args, pgIntegration, collectionList)
+		// Skip query monitoring when connected to PgBouncer admin console
+		// as it requires PostgreSQL-specific system views (pg_stat_statements, pg_stat_activity, etc.)
+		if args.Pgbouncer && args.Database == "pgbouncer" {
+			log.Debug("Skipping query performance monitoring in PgBouncer admin console mode")
+		} else {
+			queryperformancemonitoring.QueryPerformanceMain(args, pgIntegration, collectionList)
+		}
 	}
 
 }

--- a/src/main.go
+++ b/src/main.go
@@ -61,20 +61,14 @@ func main() {
 
 	connectionInfo := connection.DefaultConnectionInfo(&args)
 
-	// When connecting directly to PgBouncer admin console (DATABASE=pgbouncer),
-	// skip building collection list as it requires PostgreSQL-specific queries
-	var collectionList collection.DatabaseList
-	if args.Pgbouncer && args.Database == "pgbouncer" {
-		// PgBouncer admin console mode - initialize empty collection list
+	// Try to build collection list - if it fails, we might be connected to PgBouncer admin console
+	// The detection will happen later in PopulateMetrics
+	collectionList, err := collection.BuildCollectionList(args, connectionInfo)
+	if err != nil {
+		// Log as debug since this might be expected for PgBouncer admin console
+		log.Debug("Unable to build collection list (this is normal for PgBouncer admin console): %s", err)
+		// Initialize empty collection list - PopulateMetrics will handle detection
 		collectionList = collection.DatabaseList{}
-	} else {
-		// Standard PostgreSQL mode - build collection list normally
-		var err error
-		collectionList, err = collection.BuildCollectionList(args, connectionInfo)
-		if err != nil {
-			log.Error("Error creating list of entities to collect: %s", err)
-			os.Exit(1)
-		}
 	}
 	instance, err := pgIntegration.Entity(fmt.Sprintf("%s:%s", args.Hostname, args.Port), "pg-instance")
 	if err != nil {
@@ -89,16 +83,19 @@ func main() {
 	}
 
 	if args.HasInventory() {
-		// Skip inventory collection when connected to PgBouncer admin console
-		// as it requires PostgreSQL-specific system queries
-		if args.Pgbouncer && args.Database == "pgbouncer" {
-			log.Debug("Skipping inventory collection in PgBouncer admin console mode")
+		con, err := connectionInfo.NewConnection(connectionInfo.DatabaseName())
+		if err != nil {
+			log.Error("Inventory collection failed: error creating connection: %s", err.Error())
 		} else {
-			con, err := connectionInfo.NewConnection(connectionInfo.DatabaseName())
-			if err != nil {
-				log.Error("Inventory collection failed: error creating connection to PostgreSQL: %s", err.Error())
+			defer con.Close()
+
+			// Try to detect database type - inventory only works for PostgreSQL
+			connInfo, detectErr := metrics.DetectDatabaseType(con)
+			if detectErr != nil {
+				log.Warn("Unable to determine database type for inventory collection: %s", detectErr.Error())
+			} else if connInfo.Type == metrics.DatabaseTypePgBouncerAdmin {
+				log.Debug("Skipping inventory collection - connected to PgBouncer admin console")
 			} else {
-				defer con.Close()
 				inventory.PopulateInventory(instance, con)
 			}
 		}
@@ -109,13 +106,7 @@ func main() {
 	}
 
 	if args.EnableQueryMonitoring {
-		// Skip query monitoring when connected to PgBouncer admin console
-		// as it requires PostgreSQL-specific system views (pg_stat_statements, pg_stat_activity, etc.)
-		if args.Pgbouncer && args.Database == "pgbouncer" {
-			log.Debug("Skipping query performance monitoring in PgBouncer admin console mode")
-		} else {
-			queryperformancemonitoring.QueryPerformanceMain(args, pgIntegration, collectionList)
-		}
+		queryperformancemonitoring.QueryPerformanceMain(args, pgIntegration, collectionList)
 	}
 
 }

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -63,57 +63,97 @@ func PopulateMetrics(
 		return
 	}
 
-	// Handle based on detected database type
-	switch connInfo.Type {
-	case DatabaseTypePgBouncerAdmin:
-		// Connected to PgBouncer admin console - only collect PgBouncer metrics
-		log.Info("Detected PgBouncer admin console connection")
-		log.Info("PgBouncer version: %s", connInfo.PgBouncerVersion)
-
-		// Add version to instance entity
-		addPgBouncerVersionToInstance(instance, connInfo.PgBouncerVersion)
-
-		// Collect PgBouncer metrics
-		PopulatePgBouncerMetrics(i, con, ci)
-
-	case DatabaseTypePostgreSQL:
-		// Connected to PostgreSQL (either direct or through PgBouncer proxy)
-		// Collect all standard PostgreSQL metrics
-		log.Info("Detected PostgreSQL connection, version: %s", connInfo.PostgreSQLVersion)
-
-		PopulateInstanceMetrics(instance, connInfo.PostgreSQLVersion, con)
-		PopulateDatabaseMetrics(databaseList, connInfo.PostgreSQLVersion, i, con, ci)
-		if collectDbLocks {
-			PopulateDatabaseLockMetrics(databaseList, connInfo.PostgreSQLVersion, i, con, ci)
-		}
-		PopulateTableMetrics(databaseList, connInfo.PostgreSQLVersion, i, ci, collectBloat)
-		PopulateIndexMetrics(databaseList, i, ci)
-		if customMetricsQuery != "" {
-			PopulateCustomMetrics(customMetricsQuery, i, con, ci, instance)
-		}
-
-		// If PgBouncer flag is set, also collect PgBouncer pool metrics
-		// by connecting to the "pgbouncer" virtual database
-		if collectPgBouncer {
-			pbCon, pbErr := ci.NewConnection("pgbouncer")
-			if pbErr != nil {
-				log.Error("Error creating connection to pgbouncer database: %s", pbErr)
-			} else {
-				defer pbCon.Close()
-
-				// Try to get PgBouncer version and add to metrics
-				pbVersion, pbVerErr := tryPgBouncerVersion(pbCon)
-				if pbVerErr != nil {
-					log.Warn("Unable to collect PgBouncer version: %s", pbVerErr.Error())
-				} else {
-					log.Info("PgBouncer version: %s", pbVersion)
-					addPgBouncerVersionToInstance(instance, pbVersion)
-				}
-
-				PopulatePgBouncerMetrics(i, pbCon, ci)
-			}
-		}
+	// Handle PgBouncer admin console
+	if connInfo.Type == DatabaseTypePgBouncerAdmin {
+		collectPgBouncerAdminMetrics(connInfo, instance, i, con, ci)
+		return
 	}
+
+	// Handle PostgreSQL (direct or through proxy)
+	if connInfo.Type == DatabaseTypePostgreSQL {
+		collectPostgreSQLMetrics(connInfo, databaseList, instance, i, con, ci, collectPgBouncer, collectDbLocks, collectBloat, customMetricsQuery)
+		return
+	}
+
+	log.Error("Unknown database type detected")
+}
+
+// collectPgBouncerAdminMetrics handles metrics collection for PgBouncer admin console
+func collectPgBouncerAdminMetrics(
+	connInfo *ConnectionInfo,
+	instance *integration.Entity,
+	i *integration.Integration,
+	con *connection.PGSQLConnection,
+	ci connection.Info) {
+
+	log.Info("Detected PgBouncer admin console connection")
+	log.Info("PgBouncer version: %s", connInfo.PgBouncerVersion)
+
+	// Add version to instance entity
+	addPgBouncerVersionToInstance(instance, connInfo.PgBouncerVersion)
+
+	// Collect PgBouncer metrics
+	PopulatePgBouncerMetrics(i, con, ci)
+}
+
+// collectPostgreSQLMetrics handles metrics collection for PostgreSQL connections
+func collectPostgreSQLMetrics(
+	connInfo *ConnectionInfo,
+	databaseList collection.DatabaseList,
+	instance *integration.Entity,
+	i *integration.Integration,
+	con *connection.PGSQLConnection,
+	ci connection.Info,
+	collectPgBouncer, collectDbLocks, collectBloat bool,
+	customMetricsQuery string) {
+
+	log.Info("Detected PostgreSQL connection, version: %s", connInfo.PostgreSQLVersion)
+
+	// Collect standard PostgreSQL metrics
+	PopulateInstanceMetrics(instance, connInfo.PostgreSQLVersion, con)
+	PopulateDatabaseMetrics(databaseList, connInfo.PostgreSQLVersion, i, con, ci)
+
+	if collectDbLocks {
+		PopulateDatabaseLockMetrics(databaseList, connInfo.PostgreSQLVersion, i, con, ci)
+	}
+
+	PopulateTableMetrics(databaseList, connInfo.PostgreSQLVersion, i, ci, collectBloat)
+	PopulateIndexMetrics(databaseList, i, ci)
+
+	if customMetricsQuery != "" {
+		PopulateCustomMetrics(customMetricsQuery, i, con, ci, instance)
+	}
+
+	// If PgBouncer flag is set, also collect PgBouncer pool metrics
+	// by connecting to the "pgbouncer" virtual database
+	if collectPgBouncer {
+		collectPgBouncerPoolMetrics(instance, i, ci)
+	}
+}
+
+// collectPgBouncerPoolMetrics collects PgBouncer pool metrics when connected through proxy
+func collectPgBouncerPoolMetrics(
+	instance *integration.Entity,
+	i *integration.Integration,
+	ci connection.Info) {
+
+	pbCon, err := ci.NewConnection("pgbouncer")
+	if err != nil {
+		log.Error("Error creating connection to pgbouncer database: %s", err)
+		return
+	}
+	defer pbCon.Close()
+
+	// Try to get PgBouncer version and add to metrics
+	pbVersion, err := tryPgBouncerVersion(pbCon)
+	if err != nil {
+		log.Warn("Unable to collect PgBouncer version: %s", err.Error())
+	} else {
+		log.Info("PgBouncer version: %s", pbVersion)
+		addPgBouncerVersionToInstance(instance, pbVersion)
+	}
+
+	PopulatePgBouncerMetrics(i, pbCon, ci)
 }
 
 // PopulateCustomMetricsFromFile collects metrics defined by a custom config file

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -18,7 +18,8 @@ import (
 )
 
 const (
-	versionQuery = `SHOW server_version`
+	versionQuery          = `SHOW server_version`
+	pgbouncerVersionQuery = `SHOW VERSION`
 )
 
 // PopulateMetrics collects metrics for each type
@@ -30,6 +31,37 @@ func PopulateMetrics(
 	collectPgBouncer, collectDbLocks, collectBloat bool,
 	customMetricsQuery string) {
 
+	// When collectPgBouncer is true and DATABASE is "pgbouncer", we're connected
+	// to the PgBouncer admin console, which doesn't support standard PostgreSQL queries.
+	// In this mode, skip standard metrics and only collect PgBouncer metrics.
+	if collectPgBouncer && ci.DatabaseName() == "pgbouncer" {
+		con, err := ci.NewConnection("pgbouncer")
+		if err != nil {
+			log.Error("Error creating connection to pgbouncer admin console: %s", err)
+			return
+		}
+		defer con.Close()
+
+		// Collect PgBouncer version
+		pgbouncerVersion, err := CollectPgBouncerVersion(con)
+		if err != nil {
+			log.Warn("Unable to collect PgBouncer version: %s", err.Error())
+		} else {
+			log.Info("PgBouncer version: %s", pgbouncerVersion)
+			// Add version to instance entity
+			metricSet := instance.NewMetricSet("PostgresqlInstanceSample",
+				attribute.Attribute{Key: "displayName", Value: instance.Metadata.Name},
+				attribute.Attribute{Key: "entityName", Value: instance.Metadata.Namespace + ":" + instance.Metadata.Name},
+				attribute.Attribute{Key: "pgbouncerVersion", Value: pgbouncerVersion},
+			)
+			_ = metricSet.SetMetric("pgbouncer.version", pgbouncerVersion, metric.ATTRIBUTE)
+		}
+
+		PopulatePgBouncerMetrics(i, con, ci)
+		return
+	}
+
+	// Standard PostgreSQL metrics collection
 	con, err := ci.NewConnection(ci.DatabaseName())
 	if err != nil {
 		log.Error("Metrics collection failed: error creating connection to PostgreSQL: %s", err.Error())
@@ -54,12 +86,30 @@ func PopulateMetrics(
 		PopulateCustomMetrics(customMetricsQuery, i, con, ci, instance)
 	}
 
+	// If PgBouncer metrics are also requested in standard PostgreSQL mode,
+	// create a separate connection to the "pgbouncer" database
 	if collectPgBouncer {
 		con, err = ci.NewConnection("pgbouncer")
 		if err != nil {
 			log.Error("Error creating connection to pgbouncer database: %s", err)
 		} else {
 			defer con.Close()
+
+			// Collect PgBouncer version
+			pgbouncerVersion, err := CollectPgBouncerVersion(con)
+			if err != nil {
+				log.Warn("Unable to collect PgBouncer version: %s", err.Error())
+			} else {
+				log.Info("PgBouncer version: %s", pgbouncerVersion)
+				// Add version to instance entity
+				metricSet := instance.NewMetricSet("PostgresqlInstanceSample",
+					attribute.Attribute{Key: "displayName", Value: instance.Metadata.Name},
+					attribute.Attribute{Key: "entityName", Value: instance.Metadata.Namespace + ":" + instance.Metadata.Name},
+					attribute.Attribute{Key: "pgbouncerVersion", Value: pgbouncerVersion},
+				)
+				_ = metricSet.SetMetric("pgbouncer.version", pgbouncerVersion, metric.ATTRIBUTE)
+			}
+
 			PopulatePgBouncerMetrics(i, con, ci)
 		}
 	}
@@ -223,6 +273,10 @@ type serverVersionRow struct {
 	Version string `db:"server_version"`
 }
 
+type pgbouncerVersionRow struct {
+	Version string `db:"version"`
+}
+
 func CollectVersion(connection *connection.PGSQLConnection) (*semver.Version, error) {
 	var versionRows []*serverVersionRow
 	if err := connection.Query(&versionRows, versionQuery); err != nil {
@@ -245,6 +299,20 @@ func CollectVersion(connection *connection.PGSQLConnection) (*semver.Version, er
 	}
 
 	return &v, nil
+}
+
+// CollectPgBouncerVersion collects the PgBouncer version using SHOW VERSION
+func CollectPgBouncerVersion(connection *connection.PGSQLConnection) (string, error) {
+	var versionRows []*pgbouncerVersionRow
+	if err := connection.Query(&versionRows, pgbouncerVersionQuery); err != nil {
+		return "", err
+	}
+
+	if len(versionRows) == 0 {
+		return "", fmt.Errorf("no version information returned from PgBouncer")
+	}
+
+	return versionRows[0].Version, nil
 }
 
 // func parseSpecialVersion(version string, specialIndex int) (*semver.Version, error) {

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -22,7 +22,24 @@ const (
 	pgbouncerVersionQuery = `SHOW VERSION`
 )
 
+// DatabaseType represents the type of database we're connected to
+type DatabaseType int
+
+const (
+	DatabaseTypePostgreSQL DatabaseType = iota
+	DatabaseTypePgBouncerAdmin
+	DatabaseTypeUnknown
+)
+
+// ConnectionInfo contains information about the connected database
+type ConnectionInfo struct {
+	Type              DatabaseType
+	PostgreSQLVersion *semver.Version
+	PgBouncerVersion  string
+}
+
 // PopulateMetrics collects metrics for each type
+// It automatically detects whether we're connected to PostgreSQL or PgBouncer admin console
 func PopulateMetrics(
 	ci connection.Info,
 	databaseList collection.DatabaseList,
@@ -31,86 +48,70 @@ func PopulateMetrics(
 	collectPgBouncer, collectDbLocks, collectBloat bool,
 	customMetricsQuery string) {
 
-	// When collectPgBouncer is true and DATABASE is "pgbouncer", we're connected
-	// to the PgBouncer admin console, which doesn't support standard PostgreSQL queries.
-	// In this mode, skip standard metrics and only collect PgBouncer metrics.
-	if collectPgBouncer && ci.DatabaseName() == "pgbouncer" {
-		con, err := ci.NewConnection("pgbouncer")
-		if err != nil {
-			log.Error("Error creating connection to pgbouncer admin console: %s", err)
-			return
-		}
-		defer con.Close()
-
-		// Collect PgBouncer version
-		pgbouncerVersion, err := CollectPgBouncerVersion(con)
-		if err != nil {
-			log.Warn("Unable to collect PgBouncer version: %s", err.Error())
-		} else {
-			log.Info("PgBouncer version: %s", pgbouncerVersion)
-			// Add version to instance entity
-			metricSet := instance.NewMetricSet("PostgresqlInstanceSample",
-				attribute.Attribute{Key: "displayName", Value: instance.Metadata.Name},
-				attribute.Attribute{Key: "entityName", Value: instance.Metadata.Namespace + ":" + instance.Metadata.Name},
-				attribute.Attribute{Key: "pgbouncerVersion", Value: pgbouncerVersion},
-			)
-			_ = metricSet.SetMetric("pgbouncer.version", pgbouncerVersion, metric.ATTRIBUTE)
-		}
-
-		PopulatePgBouncerMetrics(i, con, ci)
-		return
-	}
-
-	// Standard PostgreSQL metrics collection
+	// Create connection to the configured database
 	con, err := ci.NewConnection(ci.DatabaseName())
 	if err != nil {
-		log.Error("Metrics collection failed: error creating connection to PostgreSQL: %s", err.Error())
+		log.Error("Metrics collection failed: error creating connection: %s", err.Error())
 		return
 	}
 	defer con.Close()
 
-	version, err := CollectVersion(con)
+	// Detect what type of database we're connected to by trying queries
+	connInfo, err := DetectDatabaseType(con)
 	if err != nil {
-		log.Error("Metrics collection failed: error collecting version number: %s", err.Error())
+		log.Error("Metrics collection failed: unable to determine database type: %s", err.Error())
 		return
 	}
 
-	PopulateInstanceMetrics(instance, version, con)
-	PopulateDatabaseMetrics(databaseList, version, i, con, ci)
-	if collectDbLocks {
-		PopulateDatabaseLockMetrics(databaseList, version, i, con, ci)
-	}
-	PopulateTableMetrics(databaseList, version, i, ci, collectBloat)
-	PopulateIndexMetrics(databaseList, i, ci)
-	if customMetricsQuery != "" {
-		PopulateCustomMetrics(customMetricsQuery, i, con, ci, instance)
-	}
+	// Handle based on detected database type
+	switch connInfo.Type {
+	case DatabaseTypePgBouncerAdmin:
+		// Connected to PgBouncer admin console - only collect PgBouncer metrics
+		log.Info("Detected PgBouncer admin console connection")
+		log.Info("PgBouncer version: %s", connInfo.PgBouncerVersion)
 
-	// If PgBouncer metrics are also requested in standard PostgreSQL mode,
-	// create a separate connection to the "pgbouncer" database
-	if collectPgBouncer {
-		con, err = ci.NewConnection("pgbouncer")
-		if err != nil {
-			log.Error("Error creating connection to pgbouncer database: %s", err)
-		} else {
-			defer con.Close()
+		// Add version to instance entity
+		addPgBouncerVersionToInstance(instance, connInfo.PgBouncerVersion)
 
-			// Collect PgBouncer version
-			pgbouncerVersion, err := CollectPgBouncerVersion(con)
-			if err != nil {
-				log.Warn("Unable to collect PgBouncer version: %s", err.Error())
+		// Collect PgBouncer metrics
+		PopulatePgBouncerMetrics(i, con, ci)
+
+	case DatabaseTypePostgreSQL:
+		// Connected to PostgreSQL (either direct or through PgBouncer proxy)
+		// Collect all standard PostgreSQL metrics
+		log.Info("Detected PostgreSQL connection, version: %s", connInfo.PostgreSQLVersion)
+
+		PopulateInstanceMetrics(instance, connInfo.PostgreSQLVersion, con)
+		PopulateDatabaseMetrics(databaseList, connInfo.PostgreSQLVersion, i, con, ci)
+		if collectDbLocks {
+			PopulateDatabaseLockMetrics(databaseList, connInfo.PostgreSQLVersion, i, con, ci)
+		}
+		PopulateTableMetrics(databaseList, connInfo.PostgreSQLVersion, i, ci, collectBloat)
+		PopulateIndexMetrics(databaseList, i, ci)
+		if customMetricsQuery != "" {
+			PopulateCustomMetrics(customMetricsQuery, i, con, ci, instance)
+		}
+
+		// If PgBouncer flag is set, also collect PgBouncer pool metrics
+		// by connecting to the "pgbouncer" virtual database
+		if collectPgBouncer {
+			pbCon, pbErr := ci.NewConnection("pgbouncer")
+			if pbErr != nil {
+				log.Error("Error creating connection to pgbouncer database: %s", pbErr)
 			} else {
-				log.Info("PgBouncer version: %s", pgbouncerVersion)
-				// Add version to instance entity
-				metricSet := instance.NewMetricSet("PostgresqlInstanceSample",
-					attribute.Attribute{Key: "displayName", Value: instance.Metadata.Name},
-					attribute.Attribute{Key: "entityName", Value: instance.Metadata.Namespace + ":" + instance.Metadata.Name},
-					attribute.Attribute{Key: "pgbouncerVersion", Value: pgbouncerVersion},
-				)
-				_ = metricSet.SetMetric("pgbouncer.version", pgbouncerVersion, metric.ATTRIBUTE)
-			}
+				defer pbCon.Close()
 
-			PopulatePgBouncerMetrics(i, con, ci)
+				// Try to get PgBouncer version and add to metrics
+				pbVersion, pbVerErr := tryPgBouncerVersion(pbCon)
+				if pbVerErr != nil {
+					log.Warn("Unable to collect PgBouncer version: %s", pbVerErr.Error())
+				} else {
+					log.Info("PgBouncer version: %s", pbVersion)
+					addPgBouncerVersionToInstance(instance, pbVersion)
+				}
+
+				PopulatePgBouncerMetrics(i, pbCon, ci)
+			}
 		}
 	}
 }
@@ -277,21 +278,56 @@ type pgbouncerVersionRow struct {
 	Version string `db:"version"`
 }
 
-func CollectVersion(connection *connection.PGSQLConnection) (*semver.Version, error) {
+// addPgBouncerVersionToInstance adds PgBouncer version metrics to the instance entity
+func addPgBouncerVersionToInstance(instance *integration.Entity, version string) {
+	metricSet := instance.NewMetricSet("PostgresqlInstanceSample",
+		attribute.Attribute{Key: "displayName", Value: instance.Metadata.Name},
+		attribute.Attribute{Key: "entityName", Value: instance.Metadata.Namespace + ":" + instance.Metadata.Name},
+		attribute.Attribute{Key: "pgbouncerVersion", Value: version},
+	)
+	_ = metricSet.SetMetric("pgbouncer.version", version, metric.ATTRIBUTE)
+}
+
+// DetectDatabaseType determines what type of database we're connected to
+// by attempting queries and checking which ones succeed
+func DetectDatabaseType(connection *connection.PGSQLConnection) (*ConnectionInfo, error) {
+	connInfo := &ConnectionInfo{Type: DatabaseTypeUnknown}
+
+	// First, try PostgreSQL version query
+	pgVersion, pgErr := tryPostgreSQLVersion(connection)
+	if pgErr == nil {
+		// Successfully connected to PostgreSQL (either direct or through PgBouncer proxy)
+		connInfo.Type = DatabaseTypePostgreSQL
+		connInfo.PostgreSQLVersion = pgVersion
+		return connInfo, nil
+	}
+
+	// PostgreSQL query failed, try PgBouncer admin console query
+	pbVersion, pbErr := tryPgBouncerVersion(connection)
+	if pbErr == nil {
+		// Successfully connected to PgBouncer admin console
+		connInfo.Type = DatabaseTypePgBouncerAdmin
+		connInfo.PgBouncerVersion = pbVersion
+		return connInfo, nil
+	}
+
+	// Neither worked - return both errors
+	return nil, fmt.Errorf("unable to determine database type - PostgreSQL error: %v, PgBouncer error: %v", pgErr, pbErr)
+}
+
+// tryPostgreSQLVersion attempts to get PostgreSQL version
+func tryPostgreSQLVersion(connection *connection.PGSQLConnection) (*semver.Version, error) {
 	var versionRows []*serverVersionRow
 	if err := connection.Query(&versionRows, versionQuery); err != nil {
 		return nil, err
 	}
 
+	if len(versionRows) == 0 {
+		return nil, fmt.Errorf("no version information returned")
+	}
+
 	re := regexp.MustCompile(`[0-9]+\.[0-9]+(\.[0-9])?`)
 	version := re.FindString(versionRows[0].Version)
-	// special cases for ubuntu/debian parsing
-	//version := versionRows[0].Version
-	//if strings.Contains(version, "Ubuntu") {
-	//return parseSpecialVersion(version, strings.Index(version, " (Ubuntu"))
-	//} else if strings.Contains(version, "Debian") {
-	//return parseSpecialVersion(version, strings.Index(version, " (Debian"))
-	//}
 
 	v, err := semver.ParseTolerant(version)
 	if err != nil {
@@ -301,8 +337,8 @@ func CollectVersion(connection *connection.PGSQLConnection) (*semver.Version, er
 	return &v, nil
 }
 
-// CollectPgBouncerVersion collects the PgBouncer version using SHOW VERSION
-func CollectPgBouncerVersion(connection *connection.PGSQLConnection) (string, error) {
+// tryPgBouncerVersion attempts to get PgBouncer version
+func tryPgBouncerVersion(connection *connection.PGSQLConnection) (string, error) {
 	var versionRows []*pgbouncerVersionRow
 	if err := connection.Query(&versionRows, pgbouncerVersionQuery); err != nil {
 		return "", err
@@ -314,6 +350,13 @@ func CollectPgBouncerVersion(connection *connection.PGSQLConnection) (string, er
 
 	return versionRows[0].Version, nil
 }
+
+// CollectVersion is kept for backward compatibility
+// It only works for PostgreSQL connections
+func CollectVersion(connection *connection.PGSQLConnection) (*semver.Version, error) {
+	return tryPostgreSQLVersion(connection)
+}
+
 
 // func parseSpecialVersion(version string, specialIndex int) (*semver.Version, error) {
 // partialVersion := version[:specialIndex]

--- a/src/query-performance-monitoring/query_performance_main.go
+++ b/src/query-performance-monitoring/query_performance_main.go
@@ -21,21 +21,31 @@ import (
 func QueryPerformanceMain(args args.ArgumentList, pgIntegration *integration.Integration, databaseMap collection.DatabaseList) {
 	connectionInfo := performancedbconnection.DefaultConnectionInfo(&args)
 	if len(databaseMap) == 0 {
-		log.Debug("No databases found")
+		log.Debug("No databases found for query monitoring")
 		return
 	}
 	newConnection, err := connectionInfo.NewConnection(connectionInfo.DatabaseName())
 	if err != nil {
-		log.Error("Error creating connection: ", err)
+		log.Error("Error creating connection for query monitoring: ", err)
 		return
 	}
 	defer newConnection.Close()
 
-	version, versionErr := metrics.CollectVersion(newConnection)
-	if versionErr != nil {
-		log.Error("Error fetching version: ", versionErr)
+	// Detect database type - QPM only works for PostgreSQL
+	connInfo, detectErr := metrics.DetectDatabaseType(newConnection)
+	if detectErr != nil {
+		log.Error("Error determining database type for query monitoring: ", detectErr)
 		return
 	}
+
+	// Skip QPM if connected to PgBouncer admin console
+	if connInfo.Type == metrics.DatabaseTypePgBouncerAdmin {
+		log.Debug("Skipping query performance monitoring - connected to PgBouncer admin console (only PostgreSQL databases support QPM)")
+		return
+	}
+
+	// We have PostgreSQL connection - proceed with QPM
+	version := connInfo.PostgreSQLVersion
 	versionInt := version.Major
 	if !validations.CheckPostgresVersionSupportForQueryMonitoring(versionInt) {
 		log.Debug("Postgres version: %d is not supported for query monitoring", versionInt)


### PR DESCRIPTION
# Description:
## Problem                                                                                                                              
                                                                                                                                             
  When `PGBOUNCER=true` is set with `DATABASE=pgbouncer` (connecting directly to PgBouncer admin console), the integration attempts to run   
  standard PostgreSQL queries that the admin console doesn't support, resulting in errors:                                                   
                                                                                                                                             
  Error: invalid command `SELECT datname FROM pg_database WHERE datistemplate = false;`                              
                                                                                                                                             
  The integration reported successful health checks but emitted zero `PgBouncerSample` events.                                               
                                                                                                                                             
## Solution                                                                                                                              
                                                                                                                               
  This PR adds detection for PgBouncer admin console mode and properly handles it by:                                                        
                                                                                                                                             
  1. **Detecting admin console mode**: When `PGBOUNCER=true` AND `DATABASE=pgbouncer`, skip all PostgreSQL-specific operations               
  2. **Skipping incompatible queries**:                                                                                                      
     - Collection list building (`SELECT datname FROM pg_database`)                                                                          
     - PostgreSQL version check (`SHOW server_version`)                                                                                      
     - Standard PostgreSQL metrics collection                                                                                                
     - Inventory collection (requires PostgreSQL system catalogs)                                                                            
     - Query Performance Monitoring (requires `pg_stat_statements`, etc.)                                                                    
  3. **Adding PgBouncer version collection**: Uses `SHOW VERSION` to collect PgBouncer version                                               
  4. **Collecting PgBouncer metrics only**: Runs `SHOW POOLS` and `SHOW STATS` against the admin console    