### PR TITLE
chore(deps): bump filippo.io/edwards25519 from v1.1.0 to v1.1.1 (NR-560127)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 )
 
 require (
+	filippo.io/edwards25519 v1.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
-filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+filippo.io/edwards25519 v1.1.1 h1:YpjwWWlNmGIDyXOn8zLzqiD+9TyIlPhGFG96P39uBpw=
+filippo.io/edwards25519 v1.1.1/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
# Bump `filippo.io/edwards25519` v1.1.0 → v1.1.1 (NR-560127)

Resolves CodeQL alert [#7](https://github.com/newrelic/nri-postgresql/security/code-scanning/7) — GHSA-fw7p-63qq-7hpr / CVE-2026-26958. Severity: low. SLA due 2026-10-31.

## What is the bug

`filippo.io/edwards25519` is a low-level Go library implementing the Ed25519 elliptic curve. The advisory reports that its `MultiScalarMult` function can return invalid results or undefined behavior when the result-receiver is not pre-initialized to the curve identity element. Patched upstream in v1.1.1.

## Why is `edwards25519` even in this repo

It is **not** used by any `nri-postgresql` source. It enters the module graph as a test-only transitive of `sqlx`:

```
$ go mod why -m filippo.io/edwards25519
# filippo.io/edwards25519
github.com/newrelic/nri-postgresql/src/connection
github.com/jmoiron/sqlx
github.com/jmoiron/sqlx.test
github.com/go-sql-driver/mysql
filippo.io/edwards25519
```

`sqlx` is database-agnostic and its own test code imports the MySQL driver to run cross-driver tests. The MySQL driver uses Ed25519 for `caching_sha2_password` authentication. None of this is reachable from the integration's runtime — but Go records the version in `go.sum`, and that is what CodeQL scans.

## What changed

Three lines net across two files. No Go source touched.

```diff
diff --git a/go.mod b/go.mod
@@ -15,6 +15,7 @@ require (
 )

 require (
+	filippo.io/edwards25519 v1.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect

diff --git a/go.sum b/go.sum
@@ -1,5 +1,6 @@
-filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+filippo.io/edwards25519 v1.1.1 h1:YpjwWWlNmGIDyXOn8zLzqiD+9TyIlPhGFG96P39uBpw=
+filippo.io/edwards25519 v1.1.1/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
```

The `v1.1.0/go.mod` hash on line 2 is retained on purpose: Go keeps `go.mod` hashes for older versions to support minimum-version selection across the dependency graph. The vulnerable v1.1.0 *content* hash (the `h1:FNf4ty…` line) is removed.

The same bump already shipped on sibling repo `newrelic/nri-mysql`, which has been running on v1.1.1 in production.

## Hash verification

The v1.1.1 hashes in `go.sum` come from the public Go checksum transparency log at `sum.golang.org`, not from any local choice. Anyone can re-verify:

```
$ curl -s https://sum.golang.org/lookup/filippo.io/edwards25519@v1.1.1
50225567
filippo.io/edwards25519 v1.1.1 h1:YpjwWWlNmGIDyXOn8zLzqiD+9TyIlPhGFG96P39uBpw=
filippo.io/edwards25519 v1.1.1/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=

go.sum database tree
54762033
LJdlaJUrSpEzGiDQzne2dcANheKJMnK1UqHdU+BhDYo=

— sum.golang.org Az3grpr7HXQ4s/mzdtzsAxAJo0IP7sZa3MYLfoHqh55buOnmeASg6aOLxKEfujoUfb4Z0wntWxQJyQLRxVUA8f6j7g8=
```

Lines 2–3 of that response match the two hash lines added to `go.sum` exactly. `go get` only accepts a downloaded module if its hash matches this signed log; a tampered proxy would have been rejected at install time.

## Verification — local test results

### Resolved module version

```
$ go list -m filippo.io/edwards25519
filippo.io/edwards25519 v1.1.1
```

Confirms v1.1.1 is what Go's resolver actually picks for this build, not just what `go.mod` requests.

### Unit tests with race detector (`make test` → `go test -race ./... -count=1`)

```
$ make test
=== postgresql === [ test ]: running unit tests...
?       github.com/newrelic/nri-postgresql/src                                              [no test files]
ok      github.com/newrelic/nri-postgresql/src/args                                         1.769s
ok      github.com/newrelic/nri-postgresql/src/collection                                   2.297s
ok      github.com/newrelic/nri-postgresql/src/connection                                   3.811s
ok      github.com/newrelic/nri-postgresql/src/inventory                                    2.809s
ok      github.com/newrelic/nri-postgresql/src/metrics                                      3.360s
?       github.com/newrelic/nri-postgresql/src/query-performance-monitoring                 [no test files]
?       github.com/newrelic/nri-postgresql/src/query-performance-monitoring/common-parameters  [no test files]
ok      github.com/newrelic/nri-postgresql/src/query-performance-monitoring/common-utils    4.248s
?       github.com/newrelic/nri-postgresql/src/query-performance-monitoring/datamodels      [no test files]
ok      github.com/newrelic/nri-postgresql/src/query-performance-monitoring/performance-metrics  4.847s
?       github.com/newrelic/nri-postgresql/src/query-performance-monitoring/queries         [no test files]
ok      github.com/newrelic/nri-postgresql/src/query-performance-monitoring/validations     5.279s
?       github.com/newrelic/nri-postgresql/tests/simulation                                 [no test files]

$ echo $?
0
```

Eight test packages, all `ok`. No `FAIL`. Race detector enabled. Exit code 0.

### Whole-module build

```
$ go build ./...
$ echo $?
0
```

### Static analysis

```
$ go vet ./...
$ echo $?
0
```

### Diff scope

```
$ git diff master..HEAD --stat
 .smash/smash/NR-560127.md | 42 ++++++++++++++++++++++++++++++++++++++++++
 go.mod                    |  1 +
 go.sum                    |  3 ++-
 3 files changed, 45 insertions(+), 1 deletion(-)
```

The only code-relevant changes are in `go.mod` and `go.sum`. Nothing else drifted under `go mod tidy`.

### Integration tests

Not run locally. The change is metadata-only and the integration's runtime does not call into `edwards25519`, so an integration suite has no semantically distinct surface to exercise. CI will run them on the PR.

## Risk and rollback

Risk is negligible. Patch-level upgrade, no API change in the bumped library, no source code modified, no code path in this integration reaches the patched function. Sibling repo `nri-mysql` — which actually exercises the MySQL driver in production — has been on v1.1.1 successfully.

Rollback is one command:

```
git revert <bump-commit-sha>
# or, equivalently:
go get filippo.io/edwards25519@v1.1.0 && go mod tidy
```

## Post-merge

CodeQL alert [#7](https://github.com/newrelic/nri-postgresql/security/code-scanning/7) on this repo should auto-close on the next scan after merge.