### PR TITLE
add libkrb5-dev dependency for pg_stat_monitor build

### DIFF
--- a/tests/perf-testing/latest_supported/Dockerfile
+++ b/tests/perf-testing/latest_supported/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y \
     git \
     wget \
     postgresql-server-dev-17 \
+    libkrb5-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Postgres Docker Images copy contents of postgresql.conf.sample to postgresql.conf during initialization


### PR DESCRIPTION
 ## Summary

-  Fixes integration test failures caused by missing GSSAPI dependency when building `pg_stat_monitor` extension for PostgreSQL 17
- Adds `libkrb5-dev` package to PostgreSQL 17 Docker container dependencies

  ## Problem

-   Integration tests were failing with compilation error:
              

>  **fatal error: gssapi/gssapi.h**: No such file or directory

  **This occurred because**:
  - PostgreSQL 13 uses `pg_stat_monitor` v2.3.1 (older version without GSSAPI requirement)
  - PostgreSQL 17 uses latest `pg_stat_monitor` from main branch (requires GSSAPI headers)
  - The PostgreSQL 17 Docker container was missing the `libkrb5-dev` package

  ## Solution
  Added `libkrb5-dev` to the apt-get install command in `tests/perf-testing/latest_supported/Dockerfile`. This package provides the required `gssapi/gssapi.h` header file for building modern PostgreSQL extensions.