### PR TITLE
update filippo.io/edwards25519 to v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 ## Unreleased
 
 ### security
-- Updated filippo.io/edwards25519 to v1.1.1 to address GHSA-fw7p-63qq-7hpr (CVE-2026-26958)
+- Updated filippo.io/edwards25519 to v1.1.1
 
 ## v2.28.1 - 2026-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### security
+- Updated filippo.io/edwards25519 to v1.1.1 to address GHSA-fw7p-63qq-7hpr (CVE-2026-26958)
+
 ## v2.28.1 - 2026-06-26
 
 ### ⛓️ Dependencies

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 )
 
 require (
+	filippo.io/edwards25519 v1.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
-filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+filippo.io/edwards25519 v1.1.1 h1:YpjwWWlNmGIDyXOn8zLzqiD+9TyIlPhGFG96P39uBpw=
+filippo.io/edwards25519 v1.1.1/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
## Ticket
https://new-relic.atlassian.net/browse/NR-560127
## Description
Updates the transitive dependency `filippo.io/edwards25519` from v1.1.0 to v1.1.1 to remediate security vulnerability GHSA-fw7p-63qq-7hpr.

## Changes
- Updated `filippo.io/edwards25519` from v1.1.0 → v1.1.1
- Updated `go.mod` and `go.sum` accordingly
## Testing
- Project builds successfully: `go build ./...`
- Dependencies resolved correctly: `go mod tidy`