### PR TITLE
feat: add pipeline to register released versions to agent-control catalog and agent-type files

### DIFF
--- a/.fleetControl/agentControl/linux.yml
+++ b/.fleetControl/agentControl/linux.yml
@@ -1,0 +1,70 @@
+namespace: newrelic
+name: com.newrelic.infrastructure.nri_postgresql
+version: 0.1.0
+platform: host
+operating_system: linux
+protocol_version: "1.0"
+variables:
+  config:
+    description: "nri-postgresql integration YAML consumed by the infra-agent"
+    type: yaml
+    required: true
+  custom_queries:
+    description: "nri-postgresql custom query files"
+    type: string_map
+    required: false
+    default: {}
+  version:
+    description: "Agent version"
+    type: string
+    required: true
+  oci:
+    repository:
+      description: "OCI repository name for nri-postgresql"
+      type: string
+      required: false
+      default: newrelic/nri-postgresql-artifacts
+      variants:
+        ac_config_field: "oci_repository_urls"
+        values: [ "newrelic/nri-postgresql-artifacts" ]
+deployment:
+  packages:
+    nri-postgresql:
+      download:
+        oci:
+          repository: ${nr-var:oci.repository}
+          version: ${nr-var:version}
+          public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nri-postgresql/jwks.json
+  shared_filesystem:
+    infra-agent-ohi-configs:
+      kind: dir
+      entries:
+        nri-postgresql.yaml:
+          kind: file
+          text: |
+            ${nr-var:config}
+    infra-agent-ohi-binaries:
+      kind: dir
+      entries:
+        nri-postgresql:
+          kind: file
+          copy_from_file: ${nr-sub:packages.nri-postgresql.dir}/nri-postgresql
+  # Allows setting up additional files to be used as `CUSTOM_METRICS_CONFIG` on nri-postgresql configuration
+  # It can be references as follows in values:
+  #
+  # ```
+  # custom_queries:
+  #   postgresql-custom-query.yaml: |
+  #     <CUSTOM-QUERIES-CONTENT>
+  #
+  # config:
+  #    integrations:
+  #      - name: nri-postgresql
+  #        env:
+  #          # ...
+  #          CUSTOM_METRICS_CONFIG: ${nr-path:agent_dir}/custom_queries/postgresql-custom-query.yaml
+  # ```
+  filesystem:
+    custom_queries:
+      kind: dir_content_from_map
+      source: ${nr-var:custom_queries}

--- a/.fleetControl/agentControl/windows.yml
+++ b/.fleetControl/agentControl/windows.yml
@@ -1,0 +1,70 @@
+namespace: newrelic
+name: com.newrelic.infrastructure.nri_postgresql
+version: 0.1.0
+platform: host
+operating_system: windows
+protocol_version: "1.0"
+variables:
+  config:
+    description: "nri-postgresql integration YAML consumed by the infra-agent"
+    type: yaml
+    required: true
+  custom_queries:
+    description: "nri-postgresql custom query files"
+    type: string_map
+    required: false
+    default: {}
+  version:
+    description: "Agent version"
+    type: string
+    required: true
+  oci:
+    repository:
+      description: "OCI repository name for nri-postgresql"
+      type: string
+      required: false
+      default: newrelic/nri-postgresql-artifacts
+      variants:
+        ac_config_field: "oci_repository_urls"
+        values: [ "newrelic/nri-postgresql-artifacts" ]
+deployment:
+  packages:
+    nri-postgresql:
+      download:
+        oci:
+          repository: ${nr-var:oci.repository}
+          version: ${nr-var:version}
+          public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nri-postgresql/jwks.json
+  shared_filesystem:
+    infra-agent-ohi-configs:
+      kind: dir
+      entries:
+        nri-postgresql.yaml:
+          kind: file
+          text: |
+            ${nr-var:config}
+    infra-agent-ohi-binaries:
+      kind: dir
+      entries:
+        nri-postgresql.exe:
+          kind: file
+          copy_from_file: ${nr-sub:packages.nri-postgresql.dir}\\nri-postgresql.exe
+  # Allows setting up additional files to be used as `CUSTOM_METRICS_CONFIG` on nri-postgresql configuration
+  # It can be references as follows in values:
+  #
+  # ```
+  # custom_queries:
+  #   postgresql-custom-query.yaml: |
+  #     <CUSTOM-QUERIES-CONTENT>
+  #
+  # config:
+  #    integrations:
+  #      - name: nri-postgresql
+  #        env:
+  #          # ...
+  #          CUSTOM_METRICS_CONFIG: ${nr-path:agent_dir}\custom_queries\postgresql-custom-query.yaml
+  # ```
+  filesystem:
+    custom_queries:
+      kind: dir_content_from_map
+      source: ${nr-var:custom_queries}

--- a/.fleetControl/agentControlDefinitions.yml
+++ b/.fleetControl/agentControlDefinitions.yml
@@ -1,0 +1,11 @@
+agentControlDefinitions:
+  - platform: HOST
+    supportFromAgent: 1.0.0
+    supportFromAgentControl: 1.19.0
+    content: ./agentControl/windows.yml
+    operatingSystem: WINDOWS
+  - platform: HOST
+    supportFromAgent: 1.0.0
+    supportFromAgentControl: 1.19.0
+    content: ./agentControl/linux.yml
+    operatingSystem: LINUX

--- a/.fleetControl/agentControlDefinitions.yml
+++ b/.fleetControl/agentControlDefinitions.yml
@@ -1,11 +1,11 @@
 agentControlDefinitions:
   - platform: HOST
     supportFromAgent: 1.0.0
-    supportFromAgentControl: 1.19.0
+    supportFromAgentControl: 1.21.0
     content: ./agentControl/windows.yml
     operatingSystem: WINDOWS
   - platform: HOST
     supportFromAgent: 1.0.0
-    supportFromAgentControl: 1.19.0
+    supportFromAgentControl: 1.21.0
     content: ./agentControl/linux.yml
     operatingSystem: LINUX

--- a/.fleetControl/agentDefinition.yml
+++ b/.fleetControl/agentDefinition.yml
@@ -1,0 +1,15 @@
+bindings:
+  - type: REQUIRES
+    targetType: AGENT
+    target: NRInfra
+    platform: HOST
+    operatingSystem: LINUX
+    versions:
+      - ">1.71.0"
+  - type: REQUIRES
+    targetType: AGENT
+    target: NRInfra
+    platform: HOST
+    operatingSystem: WINDOWS
+    versions:
+      - ">1.71.0"

--- a/.fleetControl/configurationDefinitions.yml
+++ b/.fleetControl/configurationDefinitions.yml
@@ -1,0 +1,13 @@
+configurationDefinitions:
+  - platform: HOST
+    description: postgresql integration configuration
+    type: agent-config
+    version: 1.0.0
+    format: yml
+    operatingSystem: LINUX
+  - platform: HOST
+    description: postgresql integration configuration
+    type: agent-config
+    version: 1.0.0
+    format: yml
+    operatingSystem: WINDOWS

--- a/.github/workflows/on_release_agent_control.yaml
+++ b/.github/workflows/on_release_agent_control.yaml
@@ -23,8 +23,6 @@ jobs:
       display_name: "PostgreSQL"
       monitoring_type: "INFRA"
       oci_registry: "docker.io/newrelic/nri-postgresql-artifacts"
-      source_repo: "newrelic/nri-postgresql"
-      metadata_git_ref: "master"
       artifacts: |
         [
           {"name":"linux-amd64","os":"linux","arch":"amd64","format":"tar+gzip","source_asset":"nri-postgresql_linux_{version}_amd64.tar.gz","source_format":"tar.gz","keep_files":["var/db/newrelic-infra/newrelic-integrations/bin/nri-postgresql"]},

--- a/.github/workflows/on_release_agent_control.yaml
+++ b/.github/workflows/on_release_agent_control.yaml
@@ -1,0 +1,39 @@
+name: Publish agent to catalog
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to process (e.g., v2.29.0)'
+        required: true
+        type: string
+  release:
+    types:
+      - released
+
+permissions:
+  contents: read
+
+jobs:
+  oci-publish:
+    uses: newrelic/coreint-automation/.github/workflows/reusable_agent_control_release.yaml@v3
+    with:
+      tag: ${{ github.event.release.tag_name || inputs.tag }}
+      agent_type: NRIPostgresql
+      display_name: "PostgreSQL"
+      monitoring_type: "INFRA"
+      oci_registry: "docker.io/newrelic/nri-postgresql-artifacts"
+      source_repo: "newrelic/nri-postgresql"
+      metadata_git_ref: "master"
+      artifacts: |
+        [
+          {"name":"linux-amd64","os":"linux","arch":"amd64","format":"tar+gzip","source_asset":"nri-postgresql_linux_{version}_amd64.tar.gz","source_format":"tar.gz","keep_files":["var/db/newrelic-infra/newrelic-integrations/bin/nri-postgresql"]},
+          {"name":"linux-arm64","os":"linux","arch":"arm64","format":"tar+gzip","source_asset":"nri-postgresql_linux_{version}_arm64.tar.gz","source_format":"tar.gz","keep_files":["var/db/newrelic-infra/newrelic-integrations/bin/nri-postgresql"]},
+          {"name":"windows-amd64","os":"windows","arch":"amd64","format":"zip","source_asset":"nri-postgresql-amd64.{version}.zip","source_format":"zip","keep_files":["New Relic/newrelic-infra/newrelic-integrations/bin/nri-postgresql.exe"]}
+        ]
+    secrets:
+      OHAI_NEWRELIC_CLIENT_ID: ${{ secrets.OHAI_NEWRELIC_CLIENT_ID }}
+      OHAI_NEWRELIC_PRIVATE_KEY: ${{ secrets.OHAI_NEWRELIC_PRIVATE_KEY }}
+      OHAI_OCI_USERNAME: ${{ secrets.OHAI_OCI_USERNAME }}
+      OHAI_OCI_PASSWORD: ${{ secrets.OHAI_OCI_PASSWORD }}
+      OHAI_APM_CONTROL_NR_LICENSE_KEY_STAGING: ${{ secrets.OHAI_APM_CONTROL_NR_LICENSE_KEY_STAGING }}


### PR DESCRIPTION
## Why
Integrated nri-postgresql into the catalog used for newrelic-control.

## What
1. Add a pipeline that uploads the binaries to an oci repository, and signs it
2. Add to the catalog the latest version and the agent-type (`linux.yml` and `windows.yml`)

## Please note
1. Pipeline has already been run for the latest nri-postgresql version, validating it works and registering that version within the supported agent-control catalog.