### PR TITLE
fix: Undo the last changelog for PostgreSQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### Security
 - Added explicit least-privilege `permissions` blocks to GitHub Actions workflows
 - Added `security-events: write` permission to the security scan workflow so scan results can be uploaded
-
 
 ## v2.29.0 - 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
-## v2.30.0 - 2026-08-24
-
-### 🛡️ Security notices
 - Added explicit least-privilege `permissions` blocks to GitHub Actions workflows
 - Added `security-events: write` permission to the security scan workflow so scan results can be uploaded
 
-### ⛓️ Dependencies
-- Updated golang patch version to v1.26.6
 
 ## v2.29.0 - 2026-07-13
 

--- a/tests/perf-testing/oldest_supported/Dockerfile
+++ b/tests/perf-testing/oldest_supported/Dockerfile
@@ -15,9 +15,11 @@ RUN echo "pg_stat_statements.track = all" >> /usr/share/postgresql/postgresql.co
 RUN echo "pg_stat_statements.save = on" >> /usr/share/postgresql/postgresql.conf.sample
 RUN echo "pg_stat_monitor.pgsm_enable_query_plan = on" >> /usr/share/postgresql/postgresql.conf.sample
 
-# Install pg_wait_sampling
+# Install pg_wait_sampling (pinned to v1.1.11, the last release supporting PostgreSQL 13;
+# master dropped PG13 support and requires PostgreSQL 14+)
 RUN git clone https://github.com/postgrespro/pg_wait_sampling.git \
     && cd pg_wait_sampling \
+    && git checkout v1.1.11 \
     && make USE_PGXS=1 \
     && make USE_PGXS=1 install \
     && cd .. \


### PR DESCRIPTION
Undoing the most recent changelog update for PostgreSQL.