### PR TITLE
Sign Windows exe during installer build to fix Defender false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### Security
+- Signed the Windows `nri-postgresql.exe` binary during the installer build, not just the `.msi` wrapper, fixing Defender/VirusTotal false-positive detections.
+
 ## v2.31.0 - 2026-09-03
 
 ### 🛡️ Security notices

--- a/build/package/windows/nri-386-installer/nri-installer.wixproj
+++ b/build/package/windows/nri-386-installer/nri-installer.wixproj
@@ -42,6 +42,8 @@
         <CreateProperty Condition="$(Year) != ''" Value="Year=$(Year);$(DefineConstants)">
             <Output TaskParameter="Value" PropertyName="DefineConstants" />
         </CreateProperty>
+        <!-- Sign the raw exe; SignInstaller below only signs the .msi wrapper. -->
+        <Exec Condition="'$(noSign)' != 'true'" Command="&quot;$(SignToolPath)signtool.exe&quot; sign /s &quot;My&quot; /d &quot;$(pfx_certificate_description)&quot; /n &quot;$(pfx_certificate_description)&quot; &quot;..\..\..\..\dist\nri-$(IntegrationName)_windows_386\New Relic\newrelic-infra\newrelic-integrations\bin\nri-$(IntegrationName).exe&quot;"/>
     </Target>
     <Target Name="SignInstaller">
         <Exec Condition="'$(noSign)' != 'true'" Command="&quot;$(SignToolPath)signtool.exe&quot; sign /s &quot;My&quot; /d &quot;$(pfx_certificate_description)&quot; /n &quot;$(pfx_certificate_description)&quot; &quot;$(OutputPath)$(OutputName).msi&quot;"/>

--- a/build/package/windows/nri-amd64-installer/nri-installer.wixproj
+++ b/build/package/windows/nri-amd64-installer/nri-installer.wixproj
@@ -42,6 +42,8 @@
         <CreateProperty Condition="$(Year) != ''" Value="Year=$(Year);$(DefineConstants)">
             <Output TaskParameter="Value" PropertyName="DefineConstants" />
         </CreateProperty>
+        <!-- Sign the raw exe; SignInstaller below only signs the .msi wrapper. -->
+        <Exec Condition="'$(noSign)' != 'true'" Command="&quot;$(SignToolPath)signtool.exe&quot; sign /s &quot;My&quot; /d &quot;$(pfx_certificate_description)&quot; /n &quot;$(pfx_certificate_description)&quot; &quot;..\..\..\..\dist\nri-$(IntegrationName)_windows_amd64\New Relic\newrelic-infra\newrelic-integrations\bin\nri-$(IntegrationName).exe&quot;"/>
     </Target>
     <Target Name="SignInstaller">
         <Exec Condition="'$(noSign)' != 'true'" Command="&quot;$(SignToolPath)signtool.exe&quot; sign /s &quot;My&quot; /d &quot;$(pfx_certificate_description)&quot; /n &quot;$(pfx_certificate_description)&quot; &quot;$(OutputPath)$(OutputName).msi&quot;"/>


### PR DESCRIPTION
## Summary
- Only the `.msi` wrapper was being signed during the Windows installer build; the packaged `nri-postgresql.exe` payload itself was shipped unsigned.
- This caused Microsoft Defender/VirusTotal false-positive malware detections on customer hosts.
- Added a `signtool.exe` step in `BeforeBuild` (both amd64 and 386 installers) to sign the raw exe before WiX harvests it into the MSI, in addition to the existing `.msi` signature.

Same fix as newrelic/nri-mssql#307 and newrelic/nri-mysql#241.

## Test plan
- [ ] Verify Windows installer build signs both the exe and the msi
- [ ] Verify `noSign` flag still skips signing in dev builds